### PR TITLE
Fix Drake deprecation warnings

### DIFF
--- a/drake_ros_core/src/ros_subscriber_system.cpp
+++ b/drake_ros_core/src/ros_subscriber_system.cpp
@@ -67,7 +67,6 @@ RosSubscriberSystem::RosSubscriberSystem(
     std::bind(&RosSubscriberSystemPrivate::handle_message, impl_.get(), std::placeholders::_1));
 
   DeclareAbstractOutputPort(
-    topic_name,
     [serializer{impl_->serializer_.get()}]() {return serializer->create_default_value();},
     [](const drake::systems::Context<double> & context, drake::AbstractValue * output_value) {
       // Transfer message from state to output port

--- a/drake_ros_core/src/ros_subscriber_system.cpp
+++ b/drake_ros_core/src/ros_subscriber_system.cpp
@@ -67,6 +67,7 @@ RosSubscriberSystem::RosSubscriberSystem(
     std::bind(&RosSubscriberSystemPrivate::handle_message, impl_.get(), std::placeholders::_1));
 
   DeclareAbstractOutputPort(
+    topic_name,
     [serializer{impl_->serializer_.get()}]() {return serializer->create_default_value();},
     [](const drake::systems::Context<double> & context, drake::AbstractValue * output_value) {
       // Transfer message from state to output port
@@ -123,8 +124,8 @@ RosSubscriberSystem::DoCalcNextUpdateTime(
   *time = context.get_time();
   drake::systems::EventCollection<drake::systems::UnrestrictedUpdateEvent<double>> & uu_events =
     events->get_mutable_unrestricted_update_events();
-  uu_events.add_event(
-    std::make_unique<drake::systems::UnrestrictedUpdateEvent<double>>(
+  uu_events.AddEvent(
+    drake::systems::UnrestrictedUpdateEvent<double>(
       drake::systems::TriggerType::kTimed, callback));
 }
 }  // namespace drake_ros_core


### PR DESCRIPTION
After building with Drake's nightly binaries on Focal 20.04 on `rolling`, I encountered a few Drake API deprecation warnings. These updates fix the warnings. I'll have a Docker build and CI working shortly to make these warnings more obvious as they happen  in realtime.

Together with #12 this will resolve #10.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/11)
<!-- Reviewable:end -->
