### PR TITLE
Docker build and CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,8 +1,5 @@
 name: drake-ros continuous integration
 on:
-  push:
-    branches:
-      - feature_ci
   pull_request:
     branches:
       - main
@@ -13,5 +10,5 @@ jobs:
     steps:
       - name: Check out current code
         uses: actions/checkout@v2
-      - name: Build drake-ros image
+      - name: Build and Test drake_ros_core
         run: docker build -f tools/containers/drake_ros_core.Dockerfile  --build-arg ROS_DISTRO=rolling .

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,17 @@
+name: drake-ros continuous integration
+on:
+  push:
+    branches:
+      - feature_ci
+  pull_request:
+    branches:
+      - main
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out current code
+        uses: actions/checkout@v2
+      - name: Build drake-ros image
+        run: docker build -f tools/containers/drake_ros_core.Dockerfile  --build-arg ROS_DISTRO=rolling .

--- a/README.md
+++ b/README.md
@@ -6,3 +6,10 @@ The intended function of this repository:
  - API to utilize ROS from a Drake program
  - Examples of how to use both Drake and ROS together
 
+
+## Docker
+### Building and Testing with Docker
+$ docker build -t drake-ros-rolling -f tools/containers/drake_ros_core.Dockerfile  --build-arg ROS_DISTRO=rolling .
+
+### Interactive Shell in Docker container
+$ docker run -it --user root drake-ros  /bin/bash

--- a/tools/containers/drake_ros_core.Dockerfile
+++ b/tools/containers/drake_ros_core.Dockerfile
@@ -28,9 +28,7 @@ COPY /${PACKAGE_NAME} ${WORKSPACE}/src/${PACKAGE_NAME}
 WORKDIR ${WORKSPACE}
 
 # install src Debian dependencies
-# TODO: Determine why test-msgs package needs to be installed manually.
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y ros-${ROS_DISTRO}-test-msgs \
     && rosdep update \
     && rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y \
     && rm -rf /var/lib/apt/lists/*

--- a/tools/containers/drake_ros_core.Dockerfile
+++ b/tools/containers/drake_ros_core.Dockerfile
@@ -1,0 +1,42 @@
+ARG ROS_DISTRO=rolling
+FROM ros:${ROS_DISTRO}-ros-base
+ARG PLATFORM=focal
+ARG PACKAGE_NAME=drake_ros_core
+
+# bootstrap tools
+RUN apt-get update && apt-get install --no-install-recommends -y \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# drake nightly binary install
+RUN curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-${PLATFORM}.tar.gz \
+    && tar -xvzf drake.tar.gz -C /opt \
+    && apt-get update \
+    && apt-get install --no-install-recommends -y $(cat "/opt/drake/share/drake/setup/packages-${PLATFORM}.txt") \
+    && rm -rf /var/lib/apt/lists/*
+
+# make root workspace
+ENV HOME=/home/${USERNAME}
+ENV WORKSPACE=${HOME}/workspace
+RUN mkdir -p ${WORKSPACE}/src \
+    && mkdir -p ${HOME}/.ros/log
+
+# copy source code into container
+COPY /${PACKAGE_NAME} ${WORKSPACE}/src/${PACKAGE_NAME}
+
+# set workspace working directory
+WORKDIR ${WORKSPACE}
+
+# install src Debian dependencies
+# TODO: Determine why test-msgs package needs to be installed manually.
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y ros-${ROS_DISTRO}-test-msgs \
+    && rosdep update \
+    && rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y \
+    && rm -rf /var/lib/apt/lists/*
+
+# build and test workspace
+RUN . /opt/ros/${ROS_DISTRO}/setup.sh \
+    && colcon build \
+    && colcon test \
+    && colcon test-result --all --verbose

--- a/tools/containers/drake_ros_core.Dockerfile
+++ b/tools/containers/drake_ros_core.Dockerfile
@@ -17,7 +17,7 @@ RUN curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drak
 
 # make root workspace
 ENV HOME=/home/${USERNAME}
-ENV WORKSPACE=${HOME}/workspace
+ENV WORKSPACE=/workspace
 RUN mkdir -p ${WORKSPACE}/src \
     && mkdir -p ${HOME}/.ros/log
 


### PR DESCRIPTION
Adds docker build, along with a very basic Github Action CI workflow:

- based on prebuilt `ros:${ROS_DISTRO}-ros-base` docker container
  (rolling to start)
- installs Drake and Drake's dependencies
- copies drake-ros source code into the container
- installs source code dependencies
- builds source code
- runs unit tests & reports results

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/13)
<!-- Reviewable:end -->
