### PR TITLE
Configure linters to comply with Drake C++ style

### DIFF
--- a/drake_ros_core/.clang-format
+++ b/drake_ros_core/.clang-format
@@ -1,0 +1,45 @@
+# -*- yaml -*-
+
+# Taken from RobotLocomotion/drake @ 73925c7eb71361e2e97601af4182ba54072d192a
+# This file determines clang-format's style settings; for details, refer to
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle:  Google
+
+Language: Cpp
+
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Specify the #include statement order.  This implements the order mandated by
+# the Google C++ Style Guide: related header, C headers, C++ headers, library
+# headers, and finally the project headers.
+#
+# To obtain updated lists of system headers used in the below expressions, see:
+# http://stackoverflow.com/questions/2027991/list-of-standard-header-files-in-c-and-c/2029106#2029106.
+IncludeCategories:
+  # Spacers used by drake/tools/formatter.py.
+  - Regex:    '^<clang-format-priority-15>$'
+    Priority: 15
+  - Regex:    '^<clang-format-priority-25>$'
+    Priority: 25
+  - Regex:    '^<clang-format-priority-35>$'
+    Priority: 35
+  - Regex:    '^<clang-format-priority-45>$'
+    Priority: 45
+  # C system headers.
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+    Priority: 20
+  # C++ system headers (as of C++17).
+  - Regex:    '^[<"](algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
+    Priority: 30
+  # Other libraries' h files (with angles).
+  - Regex:    '^<'
+    Priority: 40
+  # Your project's h files.
+  - Regex:    '^"drake'
+    Priority: 50
+  # Other libraries' h files (with quotes).
+  - Regex:    '^"'
+    Priority: 40

--- a/drake_ros_core/.clang-format
+++ b/drake_ros_core/.clang-format
@@ -38,7 +38,7 @@ IncludeCategories:
   - Regex:    '^<'
     Priority: 40
   # Your project's h files.
-  - Regex:    '^"drake'
+  - Regex:    '^"drake_ros_core'
     Priority: 50
   # Other libraries' h files (with quotes).
   - Regex:    '^"'

--- a/drake_ros_core/CMakeLists.txt
+++ b/drake_ros_core/CMakeLists.txt
@@ -60,12 +60,14 @@ install(
 )
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  find_package(test_msgs REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-
+  find_package(ament_cmake_clang_format REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_pytest REQUIRED)
+  find_package(test_msgs REQUIRED)
+
+  ament_clang_format(CONFIG_FILE .clang-format)
+  ament_cpplint()
 
   ament_add_gtest(test_pub_sub test/test_pub_sub.cpp)
 

--- a/drake_ros_core/CPPLINT.cfg
+++ b/drake_ros_core/CPPLINT.cfg
@@ -1,0 +1,58 @@
+# Taken from RobotLocomotion/drake @ 73925c7eb71361e2e97601af4182ba54072d192a
+#
+# Copyright 2016 Robot Locomotion Group @ CSAIL. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Stop searching for additional config files.
+set noparent
+
+# Disable a warning about C++ features that were not in the original
+# C++11 specification (and so might not be well-supported).  In the
+# case of Drake, our supported minimum platforms are new enough that
+# this warning is irrelevant.
+filter=-build/c++11
+
+# Drake uses `#pragma once`, not the `#ifndef FOO_H` guard.
+# https://drake.mit.edu/styleguide/cppguide.html#The__pragma_once_Guard
+filter=-build/header_guard
+filter=+build/pragma_once
+
+# Disable cpplint's include order.  We have our own via //tools:drakelint.
+filter=-build/include_order
+
+# We do not care about the whitespace details of a TODO comment.  It is not
+# relevant for easy grepping, and the GSG does not specify any particular
+# whitespace style.  (We *do* care what the "TODO(username)" itself looks like
+# because GSG forces a particular style there, but that formatting is covered
+# by the readability/todo rule, which we leave enabled.)
+filter=-whitespace/todo
+
+# TODO(#1805) Fix this.
+filter=-legal/copyright
+
+# Ignore code that isn't ours.
+exclude_files=third_party
+
+# It's not worth lint-gardening the documentation.
+exclude_files=doc

--- a/drake_ros_core/include/drake_ros_core/drake_ros.hpp
+++ b/drake_ros_core/include/drake_ros_core/drake_ros.hpp
@@ -14,56 +14,46 @@
 #ifndef DRAKE_ROS_CORE__DRAKE_ROS_HPP_
 #define DRAKE_ROS_CORE__DRAKE_ROS_HPP_
 
-#include <rosidl_runtime_c/message_type_support_struct.h>
-#include <rclcpp/clock.hpp>
-#include <rclcpp/node_options.hpp>
-#include <rclcpp/qos.hpp>
-#include <rclcpp/serialized_message.hpp>
-
 #include <functional>
 #include <memory>
 #include <string>
 
+#include <rclcpp/clock.hpp>
+#include <rclcpp/node_options.hpp>
+#include <rclcpp/qos.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <rosidl_runtime_c/message_type_support_struct.h>
+
 #include "drake_ros_core/drake_ros_interface.hpp"
 
-namespace drake_ros_core
-{
+namespace drake_ros_core {
 /// PIMPL forward declarations
 class DrakeRosPrivate;
 class Publisher;
 class Subscription;
 
 /// System that abstracts working with ROS
-class DrakeRos final : public DrakeRosInterface
-{
-public:
-  DrakeRos()
-  : DrakeRos("DrakeRosSystems", rclcpp::NodeOptions{}) {}
+class DrakeRos final : public DrakeRosInterface {
+ public:
+  DrakeRos() : DrakeRos("DrakeRosSystems", rclcpp::NodeOptions{}) {}
 
-  DrakeRos(
-    const std::string & node_name,
-    rclcpp::NodeOptions node_options);
+  DrakeRos(const std::string& node_name, rclcpp::NodeOptions node_options);
 
   virtual ~DrakeRos();
 
-  std::unique_ptr<Publisher>
-  create_publisher(
-    const rosidl_message_type_support_t & ts,
-    const std::string & topic_name,
-    const rclcpp::QoS & qos) final;
+  std::unique_ptr<Publisher> create_publisher(
+      const rosidl_message_type_support_t& ts, const std::string& topic_name,
+      const rclcpp::QoS& qos) final;
 
-  std::shared_ptr<Subscription>
-  create_subscription(
-    const rosidl_message_type_support_t & ts,
-    const std::string & topic_name,
-    const rclcpp::QoS & qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback) final;
+  std::shared_ptr<Subscription> create_subscription(
+      const rosidl_message_type_support_t& ts, const std::string& topic_name,
+      const rclcpp::QoS& qos,
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+      final;
 
-  void
-  spin(
-    int timeout_millis) final;
+  void spin(int timeout_millis) final;
 
-private:
+ private:
   std::unique_ptr<DrakeRosPrivate> impl_;
 };
 }  // namespace drake_ros_core

--- a/drake_ros_core/include/drake_ros_core/drake_ros_interface.hpp
+++ b/drake_ros_core/include/drake_ros_core/drake_ros_interface.hpp
@@ -14,44 +14,34 @@
 #ifndef DRAKE_ROS_CORE__DRAKE_ROS_INTERFACE_HPP_
 #define DRAKE_ROS_CORE__DRAKE_ROS_INTERFACE_HPP_
 
-#include <rosidl_runtime_c/message_type_support_struct.h>
-#include <rclcpp/clock.hpp>
-#include <rclcpp/qos.hpp>
-#include <rclcpp/serialized_message.hpp>
-
 #include <functional>
 #include <memory>
 #include <string>
 
-namespace drake_ros_core
-{
+#include <rclcpp/clock.hpp>
+#include <rclcpp/qos.hpp>
+#include <rclcpp/serialized_message.hpp>
+#include <rosidl_runtime_c/message_type_support_struct.h>
+
+namespace drake_ros_core {
 // Forward declarations for non-public-API classes
 class Publisher;
 class Subscription;
 
 /// System that abstracts working with ROS
-class DrakeRosInterface
-{
-public:
-  virtual
-  std::unique_ptr<Publisher>
-  create_publisher(
-    const rosidl_message_type_support_t & ts,
-    const std::string & topic_name,
-    const rclcpp::QoS & qos) = 0;
+class DrakeRosInterface {
+ public:
+  virtual std::unique_ptr<Publisher> create_publisher(
+      const rosidl_message_type_support_t& ts, const std::string& topic_name,
+      const rclcpp::QoS& qos) = 0;
 
-  virtual
-  std::shared_ptr<Subscription>
-  create_subscription(
-    const rosidl_message_type_support_t & ts,
-    const std::string & topic_name,
-    const rclcpp::QoS & qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback) = 0;
+  virtual std::shared_ptr<Subscription> create_subscription(
+      const rosidl_message_type_support_t& ts, const std::string& topic_name,
+      const rclcpp::QoS& qos,
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)>
+          callback) = 0;
 
-  virtual
-  void
-  spin(
-    int timeout_millis) = 0;
+  virtual void spin(int timeout_millis) = 0;
 };
 }  // namespace drake_ros_core
 #endif  // DRAKE_ROS_CORE__DRAKE_ROS_INTERFACE_HPP_

--- a/drake_ros_core/include/drake_ros_core/ros_interface_system.hpp
+++ b/drake_ros_core/include/drake_ros_core/ros_interface_system.hpp
@@ -14,34 +14,30 @@
 #ifndef DRAKE_ROS_CORE__ROS_INTERFACE_SYSTEM_HPP_
 #define DRAKE_ROS_CORE__ROS_INTERFACE_SYSTEM_HPP_
 
-#include <drake/systems/framework/leaf_system.h>
-
 #include <memory>
+
+#include <drake/systems/framework/leaf_system.h>
 
 #include "drake_ros_core/drake_ros_interface.hpp"
 
-namespace drake_ros_core
-{
+namespace drake_ros_core {
 // PIMPL forward declaration
 class RosInterfaceSystemPrivate;
 
 /// System that takes care of calling spin() in Drake's systems framework
-class RosInterfaceSystem : public drake::systems::LeafSystem<double>
-{
-public:
+class RosInterfaceSystem : public drake::systems::LeafSystem<double> {
+ public:
   explicit RosInterfaceSystem(std::unique_ptr<DrakeRosInterface> ros);
   virtual ~RosInterfaceSystem();
 
   /// Return a handle for interacting with ROS
-  std::shared_ptr<DrakeRosInterface>
-  get_ros_interface() const;
+  std::shared_ptr<DrakeRosInterface> get_ros_interface() const;
 
-protected:
+ protected:
   /// Override as a place to call rclcpp::spin()
-  void DoCalcNextUpdateTime(
-    const drake::systems::Context<double> &,
-    drake::systems::CompositeEventCollection<double> *,
-    double *) const override;
+  void DoCalcNextUpdateTime(const drake::systems::Context<double>&,
+                            drake::systems::CompositeEventCollection<double>*,
+                            double*) const override;
 
   std::unique_ptr<RosInterfaceSystemPrivate> impl_;
 };

--- a/drake_ros_core/include/drake_ros_core/ros_subscriber_system.hpp
+++ b/drake_ros_core/include/drake_ros_core/ros_subscriber_system.hpp
@@ -14,53 +14,47 @@
 #ifndef DRAKE_ROS_CORE__ROS_SUBSCRIBER_SYSTEM_HPP_
 #define DRAKE_ROS_CORE__ROS_SUBSCRIBER_SYSTEM_HPP_
 
-#include <drake/systems/framework/leaf_system.h>
-#include <rosidl_typesupport_cpp/message_type_support.hpp>
-
 #include <memory>
 #include <string>
+
+#include <drake/systems/framework/leaf_system.h>
+#include <rosidl_typesupport_cpp/message_type_support.hpp>
 
 #include "drake_ros_core/drake_ros_interface.hpp"
 #include "drake_ros_core/serializer.hpp"
 #include "drake_ros_core/serializer_interface.hpp"
 
-namespace drake_ros_core
-{
+namespace drake_ros_core {
 // PIMPL forward declaration
 class RosSubscriberSystemPrivate;
 
-/// System that subscribes to a ROS topic and makes it available on an output port
-class RosSubscriberSystem : public drake::systems::LeafSystem<double>
-{
-public:
+/// System that subscribes to a ROS topic and makes it available on an output
+/// port
+class RosSubscriberSystem : public drake::systems::LeafSystem<double> {
+ public:
   /// Convenience method to make a subscriber system given a ROS message type
-  template<typename MessageT>
-  static
-  std::unique_ptr<RosSubscriberSystem>
-  Make(
-    const std::string & topic_name,
-    const rclcpp::QoS & qos,
-    std::shared_ptr<DrakeRosInterface> ros_interface)
-  {
+  template <typename MessageT>
+  static std::unique_ptr<RosSubscriberSystem> Make(
+      const std::string& topic_name, const rclcpp::QoS& qos,
+      std::shared_ptr<DrakeRosInterface> ros_interface) {
     // Assume C++ typesupport since this is a C++ template function
-    std::unique_ptr<SerializerInterface> serializer = std::make_unique<Serializer<MessageT>>();
-    return std::make_unique<RosSubscriberSystem>(serializer, topic_name, qos, ros_interface);
+    std::unique_ptr<SerializerInterface> serializer =
+        std::make_unique<Serializer<MessageT>>();
+    return std::make_unique<RosSubscriberSystem>(serializer, topic_name, qos,
+                                                 ros_interface);
   }
 
-  RosSubscriberSystem(
-    std::unique_ptr<SerializerInterface> & serializer,
-    const std::string & topic_name,
-    const rclcpp::QoS & qos,
-    std::shared_ptr<DrakeRosInterface> ros_interface);
+  RosSubscriberSystem(std::unique_ptr<SerializerInterface>& serializer,
+                      const std::string& topic_name, const rclcpp::QoS& qos,
+                      std::shared_ptr<DrakeRosInterface> ros_interface);
 
   virtual ~RosSubscriberSystem();
 
-protected:
+ protected:
   /// Override as a place to schedule event to move ROS message into a context
-  void DoCalcNextUpdateTime(
-    const drake::systems::Context<double> &,
-    drake::systems::CompositeEventCollection<double> *,
-    double *) const override;
+  void DoCalcNextUpdateTime(const drake::systems::Context<double>&,
+                            drake::systems::CompositeEventCollection<double>*,
+                            double*) const override;
 
   std::unique_ptr<RosSubscriberSystemPrivate> impl_;
 };

--- a/drake_ros_core/include/drake_ros_core/serializer.hpp
+++ b/drake_ros_core/include/drake_ros_core/serializer.hpp
@@ -14,32 +14,26 @@
 #ifndef DRAKE_ROS_CORE__SERIALIZER_HPP_
 #define DRAKE_ROS_CORE__SERIALIZER_HPP_
 
-#include <drake/common/value.h>
-#include <rmw/rmw.h>
-
-#include <rclcpp/serialized_message.hpp>
-#include <rosidl_typesupport_cpp/message_type_support.hpp>
-
 #include <memory>
+
+#include <drake/common/value.h>
+#include <rclcpp/serialized_message.hpp>
+#include <rmw/rmw.h>
+#include <rosidl_typesupport_cpp/message_type_support.hpp>
 
 #include "drake_ros_core/serializer_interface.hpp"
 
-
-namespace drake_ros_core
-{
-template<typename MessageT>
-class Serializer : public SerializerInterface
-{
-public:
-  rclcpp::SerializedMessage
-  serialize(const drake::AbstractValue & abstract_value) const override
-  {
+namespace drake_ros_core {
+template <typename MessageT>
+class Serializer : public SerializerInterface {
+ public:
+  rclcpp::SerializedMessage serialize(
+      const drake::AbstractValue& abstract_value) const override {
     rclcpp::SerializedMessage serialized_msg;
-    const MessageT & message = abstract_value.get_value<MessageT>();
-    const auto ret = rmw_serialize(
-      &message,
-      get_type_support(),
-      &serialized_msg.get_rcl_serialized_message());
+    const MessageT& message = abstract_value.get_value<MessageT>();
+    const auto ret =
+        rmw_serialize(&message, get_type_support(),
+                      &serialized_msg.get_rcl_serialized_message());
     if (ret != RMW_RET_OK) {
       // TODO(sloretz) do something if serialization fails
       (void)ret;
@@ -47,27 +41,19 @@ public:
     return serialized_msg;
   }
 
-  bool
-  deserialize(
-    const rclcpp::SerializedMessage & serialized_message,
-    drake::AbstractValue & abstract_value) const override
-  {
+  bool deserialize(const rclcpp::SerializedMessage& serialized_message,
+                   drake::AbstractValue& abstract_value) const override {
     const auto ret = rmw_deserialize(
-      &serialized_message.get_rcl_serialized_message(),
-      get_type_support(),
-      &abstract_value.get_mutable_value<MessageT>());
+        &serialized_message.get_rcl_serialized_message(), get_type_support(),
+        &abstract_value.get_mutable_value<MessageT>());
     return ret == RMW_RET_OK;
   }
 
-  std::unique_ptr<drake::AbstractValue>
-  create_default_value() const override
-  {
+  std::unique_ptr<drake::AbstractValue> create_default_value() const override {
     return std::make_unique<drake::Value<MessageT>>(MessageT());
   }
 
-  const rosidl_message_type_support_t *
-  get_type_support() const override
-  {
+  const rosidl_message_type_support_t* get_type_support() const override {
     return rosidl_typesupport_cpp::get_message_type_support_handle<MessageT>();
   }
 };

--- a/drake_ros_core/include/drake_ros_core/serializer_interface.hpp
+++ b/drake_ros_core/include/drake_ros_core/serializer_interface.hpp
@@ -14,34 +14,25 @@
 #ifndef DRAKE_ROS_CORE__SERIALIZER_INTERFACE_HPP_
 #define DRAKE_ROS_CORE__SERIALIZER_INTERFACE_HPP_
 
+#include <memory>
+
 #include <drake/common/value.h>
 #include <rclcpp/serialized_message.hpp>
 #include <rosidl_typesupport_cpp/message_type_support.hpp>
 
-#include <memory>
+namespace drake_ros_core {
+class SerializerInterface {
+ public:
+  virtual rclcpp::SerializedMessage serialize(
+      const drake::AbstractValue& abstract_value) const = 0;
 
-namespace drake_ros_core
-{
-class SerializerInterface
-{
-public:
-  virtual
-  rclcpp::SerializedMessage
-  serialize(const drake::AbstractValue & abstract_value) const = 0;
+  virtual bool deserialize(const rclcpp::SerializedMessage& message,
+                           drake::AbstractValue& abstract_value) const = 0;
 
-  virtual
-  bool
-  deserialize(
-    const rclcpp::SerializedMessage & message,
-    drake::AbstractValue & abstract_value) const = 0;
+  virtual std::unique_ptr<drake::AbstractValue> create_default_value()
+      const = 0;
 
-  virtual
-  std::unique_ptr<drake::AbstractValue>
-  create_default_value() const = 0;
-
-  virtual
-  const rosidl_message_type_support_t *
-  get_type_support() const = 0;
+  virtual const rosidl_message_type_support_t* get_type_support() const = 0;
 };
 }  // namespace drake_ros_core
 #endif  // DRAKE_ROS_CORE__SERIALIZER_INTERFACE_HPP_

--- a/drake_ros_core/package.xml
+++ b/drake_ros_core/package.xml
@@ -14,9 +14,10 @@
   <depend>rosidl_runtime_c</depend>
   <depend>rosidl_typesupport_cpp</depend>
 
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
-  <test_depend>ament_lint_auto</test_depend>
-  <test_depend>ament_lint_common</test_depend>
+  <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>test_msgs</test_depend>
 
   <export>

--- a/drake_ros_core/src/drake_ros.cpp
+++ b/drake_ros_core/src/drake_ros.cpp
@@ -12,34 +12,31 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <rclcpp/executors.hpp>
-#include <rclcpp/node.hpp>
+#include "drake_ros_core/drake_ros.hpp"
 
 #include <memory>
 #include <string>
 
-#include "drake_ros_core/drake_ros.hpp"
 #include "publisher.hpp"
 #include "subscription.hpp"
+#include <rclcpp/executors.hpp>
+#include <rclcpp/node.hpp>
 
-namespace drake_ros_core
-{
-class DrakeRosPrivate
-{
-public:
+namespace drake_ros_core {
+class DrakeRosPrivate {
+ public:
   bool externally_init_;
   rclcpp::Context::SharedPtr context_;
   rclcpp::Node::UniquePtr node_;
   rclcpp::executors::SingleThreadedExecutor::UniquePtr executor_;
 };
 
-DrakeRos::DrakeRos(
-  const std::string & node_name,
-  rclcpp::NodeOptions node_options)
-: impl_(new DrakeRosPrivate())
-{
+DrakeRos::DrakeRos(const std::string& node_name,
+                   rclcpp::NodeOptions node_options)
+    : impl_(new DrakeRosPrivate()) {
   if (!node_options.context()) {
-    // Require context is constructed (NodeOptions uses Global Context by default)
+    // Require context is constructed (NodeOptions uses Global Context by
+    // default)
     throw std::invalid_argument("NodeOptions must contain a non-null context");
   }
   impl_->context_ = node_options.context();
@@ -62,42 +59,33 @@ DrakeRos::DrakeRos(
   impl_->executor_->add_node(impl_->node_->get_node_base_interface());
 }
 
-DrakeRos::~DrakeRos()
-{
+DrakeRos::~DrakeRos() {
   if (!impl_->externally_init_) {
     // This system init'd the context, so this system will shut it down too.
     impl_->context_->shutdown("~DrakeRos()");
   }
 }
 
-std::unique_ptr<Publisher>
-DrakeRos::create_publisher(
-  const rosidl_message_type_support_t & ts,
-  const std::string & topic_name,
-  const rclcpp::QoS & qos)
-{
+std::unique_ptr<Publisher> DrakeRos::create_publisher(
+    const rosidl_message_type_support_t& ts, const std::string& topic_name,
+    const rclcpp::QoS& qos) {
   return std::make_unique<Publisher>(
-    impl_->node_->get_node_base_interface().get(), ts, topic_name, qos);
+      impl_->node_->get_node_base_interface().get(), ts, topic_name, qos);
 }
 
-std::shared_ptr<Subscription>
-DrakeRos::create_subscription(
-  const rosidl_message_type_support_t & ts,
-  const std::string & topic_name,
-  const rclcpp::QoS & qos,
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
-{
+std::shared_ptr<Subscription> DrakeRos::create_subscription(
+    const rosidl_message_type_support_t& ts, const std::string& topic_name,
+    const rclcpp::QoS& qos,
+    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback) {
   auto sub = std::make_shared<Subscription>(
-    impl_->node_->get_node_base_interface().get(), ts, topic_name, qos, callback);
+      impl_->node_->get_node_base_interface().get(), ts, topic_name, qos,
+      callback);
   impl_->node_->get_node_topics_interface()->add_subscription(sub, nullptr);
 
   return sub;
 }
 
-void
-DrakeRos::spin(
-  int timeout_millis)
-{
+void DrakeRos::spin(int timeout_millis) {
   impl_->executor_->spin_some(std::chrono::milliseconds(timeout_millis));
 }
 }  // namespace drake_ros_core

--- a/drake_ros_core/src/publisher.cpp
+++ b/drake_ros_core/src/publisher.cpp
@@ -12,42 +12,36 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
-
 #include "publisher.hpp"
 
-namespace drake_ros_core
-{
+#include <string>
+
+namespace drake_ros_core {
 // Copied from rosbag2_transport rosbag2_get_publisher_options
-rcl_publisher_options_t publisher_options(const rclcpp::QoS & qos)
-{
+rcl_publisher_options_t publisher_options(const rclcpp::QoS& qos) {
   auto options = rcl_publisher_get_default_options();
   options.qos = qos.get_rmw_qos_profile();
   return options;
 }
 
-Publisher::Publisher(
-  rclcpp::node_interfaces::NodeBaseInterface * node_base,
-  const rosidl_message_type_support_t & type_support,
-  const std::string & topic_name,
-  const rclcpp::QoS & qos)
-: rclcpp::PublisherBase(node_base, topic_name, type_support, publisher_options(qos))
-{
-}
+Publisher::Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
+                     const rosidl_message_type_support_t& type_support,
+                     const std::string& topic_name, const rclcpp::QoS& qos)
+    : rclcpp::PublisherBase(node_base, topic_name, type_support,
+                            publisher_options(qos)) {}
 
-Publisher::~Publisher()
-{
-}
+Publisher::~Publisher() {}
 
-void
-Publisher::publish(const rclcpp::SerializedMessage & serialized_msg)
-{
-  // TODO(sloretz) Copied from rosbag2_transport GenericPublisher, can it be upstreamed to rclcpp?
+void Publisher::publish(const rclcpp::SerializedMessage& serialized_msg) {
+  // TODO(sloretz) Copied from rosbag2_transport GenericPublisher, can it be
+  // upstreamed to rclcpp?
   auto return_code = rcl_publish_serialized_message(
-    get_publisher_handle().get(), &serialized_msg.get_rcl_serialized_message(), NULL);
+      get_publisher_handle().get(),
+      &serialized_msg.get_rcl_serialized_message(), NULL);
 
   if (return_code != RCL_RET_OK) {
-    rclcpp::exceptions::throw_from_rcl_error(return_code, "failed to publish serialized message");
+    rclcpp::exceptions::throw_from_rcl_error(
+        return_code, "failed to publish serialized message");
   }
 }
 }  // namespace drake_ros_core

--- a/drake_ros_core/src/publisher.hpp
+++ b/drake_ros_core/src/publisher.hpp
@@ -14,31 +14,24 @@
 #ifndef PUBLISHER_HPP_
 #define PUBLISHER_HPP_
 
-#include <rosidl_runtime_c/message_type_support_struct.h>
+#include <memory>
+#include <string>
 
 #include <rclcpp/publisher_base.hpp>
 #include <rclcpp/qos.hpp>
 #include <rclcpp/serialized_message.hpp>
+#include <rosidl_runtime_c/message_type_support_struct.h>
 
-#include <memory>
-#include <string>
-
-
-namespace drake_ros_core
-{
-class Publisher final : public rclcpp::PublisherBase
-{
-public:
-  Publisher(
-    rclcpp::node_interfaces::NodeBaseInterface * node_base,
-    const rosidl_message_type_support_t & ts,
-    const std::string & topic_name,
-    const rclcpp::QoS & qos);
+namespace drake_ros_core {
+class Publisher final : public rclcpp::PublisherBase {
+ public:
+  Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
+            const rosidl_message_type_support_t& ts,
+            const std::string& topic_name, const rclcpp::QoS& qos);
 
   ~Publisher();
 
-  void
-  publish(const rclcpp::SerializedMessage & serialized_msg);
+  void publish(const rclcpp::SerializedMessage& serialized_msg);
 };
 }  // namespace drake_ros_core
 #endif  // PUBLISHER_HPP_

--- a/drake_ros_core/src/ros_interface_system.cpp
+++ b/drake_ros_core/src/ros_interface_system.cpp
@@ -12,50 +12,41 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "drake_ros_core/ros_interface_system.hpp"
+
 #include <limits>
 #include <memory>
 #include <utility>
 
-#include "drake_ros_core/ros_interface_system.hpp"
-
-namespace drake_ros_core
-{
-class RosInterfaceSystemPrivate
-{
-public:
+namespace drake_ros_core {
+class RosInterfaceSystemPrivate {
+ public:
   std::shared_ptr<DrakeRosInterface> ros_;
 };
 
-
 RosInterfaceSystem::RosInterfaceSystem(std::unique_ptr<DrakeRosInterface> ros)
-: impl_(new RosInterfaceSystemPrivate())
-{
+    : impl_(new RosInterfaceSystemPrivate()) {
   impl_->ros_ = std::move(ros);
 }
 
-RosInterfaceSystem::~RosInterfaceSystem()
-{
-}
+RosInterfaceSystem::~RosInterfaceSystem() {}
 
 /// Return a handle for interacting with ROS
-std::shared_ptr<DrakeRosInterface>
-RosInterfaceSystem::get_ros_interface() const
-{
+std::shared_ptr<DrakeRosInterface> RosInterfaceSystem::get_ros_interface()
+    const {
   return impl_->ros_;
 }
 
 /// Override as a place to call rclcpp::spin()
-void
-RosInterfaceSystem::DoCalcNextUpdateTime(
-  const drake::systems::Context<double> &,
-  drake::systems::CompositeEventCollection<double> *,
-  double * time) const
-{
-  // Do work for at most 1ms so system doesn't get blocked if there's more work than it can handle
+void RosInterfaceSystem::DoCalcNextUpdateTime(
+    const drake::systems::Context<double>&,
+    drake::systems::CompositeEventCollection<double>*, double* time) const {
+  // Do work for at most 1ms so system doesn't get blocked if there's more work
+  // than it can handle
   const int max_work_time_millis = 1;
   impl_->ros_->spin(max_work_time_millis);
-  // TODO(sloretz) Lcm system pauses time if some work was done, but ROS 2 API doesn't say if
-  // any work was done. How to reconcile that?
+  // TODO(sloretz) Lcm system pauses time if some work was done, but ROS 2 API
+  // doesn't say if any work was done. How to reconcile that?
   *time = std::numeric_limits<double>::infinity();
 }
 }  // namespace drake_ros_core

--- a/drake_ros_core/src/ros_publisher_system.cpp
+++ b/drake_ros_core/src/ros_publisher_system.cpp
@@ -12,99 +12,92 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "drake_ros_core/ros_publisher_system.hpp"
+
 #include <memory>
 #include <string>
 #include <unordered_set>
 #include <utility>
 
-#include "drake_ros_core/ros_publisher_system.hpp"
-#include "drake_ros_core/serializer_interface.hpp"
-
 #include "publisher.hpp"
 
-namespace drake_ros_core
-{
-class RosPublisherSystemPrivate
-{
-public:
+#include "drake_ros_core/serializer_interface.hpp"
+
+namespace drake_ros_core {
+class RosPublisherSystemPrivate {
+ public:
   std::unique_ptr<SerializerInterface> serializer_;
   std::unique_ptr<Publisher> pub_;
 };
 
 RosPublisherSystem::RosPublisherSystem(
-  std::unique_ptr<SerializerInterface> & serializer,
-  const std::string & topic_name,
-  const rclcpp::QoS & qos,
-  std::shared_ptr<DrakeRosInterface> ros,
-  const std::unordered_set<drake::systems::TriggerType> & publish_triggers,
-  double publish_period)
-: impl_(new RosPublisherSystemPrivate())
-{
+    std::unique_ptr<SerializerInterface>& serializer,
+    const std::string& topic_name, const rclcpp::QoS& qos,
+    std::shared_ptr<DrakeRosInterface> ros,
+    const std::unordered_set<drake::systems::TriggerType>& publish_triggers,
+    double publish_period)
+    : impl_(new RosPublisherSystemPrivate()) {
   impl_->serializer_ = std::move(serializer);
-  impl_->pub_ = ros->create_publisher(
-    *impl_->serializer_->get_type_support(), topic_name, qos);
+  impl_->pub_ = ros->create_publisher(*impl_->serializer_->get_type_support(),
+                                      topic_name, qos);
 
-  DeclareAbstractInputPort("message", *(impl_->serializer_->create_default_value()));
+  DeclareAbstractInputPort("message",
+                           *(impl_->serializer_->create_default_value()));
 
   // vvv Mostly copied from LcmPublisherSystem vvv
   // Check that publish_triggers does not contain an unsupported trigger.
-  for (const auto & trigger : publish_triggers) {
-    if (
-      (trigger != drake::systems::TriggerType::kForced) &&
-      (trigger != drake::systems::TriggerType::kPeriodic) &&
-      (trigger != drake::systems::TriggerType::kPerStep))
-    {
-      throw std::invalid_argument("Only kForced, kPeriodic, or kPerStep are supported");
+  for (const auto& trigger : publish_triggers) {
+    if ((trigger != drake::systems::TriggerType::kForced) &&
+        (trigger != drake::systems::TriggerType::kPeriodic) &&
+        (trigger != drake::systems::TriggerType::kPerStep)) {
+      throw std::invalid_argument(
+          "Only kForced, kPeriodic, or kPerStep are supported");
     }
   }
 
   // Declare a forced publish so that any time Publish(.) is called on this
   // system (or a Diagram containing it), a message is emitted.
-  if (publish_triggers.find(drake::systems::TriggerType::kForced) != publish_triggers.end()) {
-    this->DeclareForcedPublishEvent(
-      &RosPublisherSystem::publish_input);
+  if (publish_triggers.find(drake::systems::TriggerType::kForced) !=
+      publish_triggers.end()) {
+    this->DeclareForcedPublishEvent(&RosPublisherSystem::publish_input);
   }
 
-  if (publish_triggers.find(drake::systems::TriggerType::kPeriodic) != publish_triggers.end()) {
+  if (publish_triggers.find(drake::systems::TriggerType::kPeriodic) !=
+      publish_triggers.end()) {
     if (publish_period <= 0.0) {
       throw std::invalid_argument("kPeriodic requires publish_period > 0");
     }
     const double offset = 0.0;
-    this->DeclarePeriodicPublishEvent(
-      publish_period, offset,
-      &RosPublisherSystem::publish_input);
+    this->DeclarePeriodicPublishEvent(publish_period, offset,
+                                      &RosPublisherSystem::publish_input);
   } else if (publish_period > 0) {
-    // publish_period > 0 without drake::systems::TriggerType::kPeriodic has no meaning and is
-    // likely a mistake.
+    // publish_period > 0 without drake::systems::TriggerType::kPeriodic has no
+    // meaning and is likely a mistake.
     throw std::invalid_argument("publish_period > 0 requires kPeriodic");
   }
 
-  if (publish_triggers.find(drake::systems::TriggerType::kPerStep) != publish_triggers.end()) {
-    DeclarePerStepEvent(
-      drake::systems::PublishEvent<double>(
-        [this](
-          const drake::systems::Context<double> & context,
-          const drake::systems::PublishEvent<double> &) {
+  if (publish_triggers.find(drake::systems::TriggerType::kPerStep) !=
+      publish_triggers.end()) {
+    DeclarePerStepEvent(drake::systems::PublishEvent<double>(
+        [this](const drake::systems::Context<double>& context,
+               const drake::systems::PublishEvent<double>&) {
           publish_input(context);
         }));
   }
   // ^^^ Mostly copied from LcmPublisherSystem ^^^
 }
 
-RosPublisherSystem::~RosPublisherSystem()
-{
-}
+RosPublisherSystem::~RosPublisherSystem() {}
 
-void
-RosPublisherSystem::publish(const rclcpp::SerializedMessage & serialized_msg)
-{
+void RosPublisherSystem::publish(
+    const rclcpp::SerializedMessage& serialized_msg) {
   impl_->pub_->publish(serialized_msg);
 }
 
-drake::systems::EventStatus
-RosPublisherSystem::publish_input(const drake::systems::Context<double> & context) const
-{
-  const drake::AbstractValue & input = get_input_port().Eval<drake::AbstractValue>(context);
+drake::systems::EventStatus RosPublisherSystem::publish_input(
+    const drake::systems::Context<double>& context) const {
+  const drake::AbstractValue& input =
+      get_input_port().Eval<drake::AbstractValue>(context);
   impl_->pub_->publish(impl_->serializer_->serialize(input));
   return drake::systems::EventStatus::Succeeded();
 }

--- a/drake_ros_core/src/subscription.cpp
+++ b/drake_ros_core/src/subscription.cpp
@@ -16,82 +16,65 @@
 #include <memory>
 #include <string>
 
-namespace drake_ros_core
-{
+namespace drake_ros_core {
 // Copied from rosbag2_transport rosbag2_get_subscription_options
-rcl_subscription_options_t subscription_options(const rclcpp::QoS & qos)
-{
+rcl_subscription_options_t subscription_options(const rclcpp::QoS& qos) {
   auto options = rcl_subscription_get_default_options();
   options.qos = qos.get_rmw_qos_profile();
   return options;
 }
 
 Subscription::Subscription(
-  rclcpp::node_interfaces::NodeBaseInterface * node_base,
-  const rosidl_message_type_support_t & ts,
-  const std::string & topic_name,
-  const rclcpp::QoS & qos,
-  std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
-: rclcpp::SubscriptionBase(node_base, ts, topic_name, subscription_options(qos), true),
-  callback_(callback)
-{
-}
+    rclcpp::node_interfaces::NodeBaseInterface* node_base,
+    const rosidl_message_type_support_t& ts, const std::string& topic_name,
+    const rclcpp::QoS& qos,
+    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+    : rclcpp::SubscriptionBase(node_base, ts, topic_name,
+                               subscription_options(qos), true),
+      callback_(callback) {}
 
-Subscription::~Subscription()
-{
-}
+Subscription::~Subscription() {}
 
-std::shared_ptr<void>
-Subscription::create_message()
-{
+std::shared_ptr<void> Subscription::create_message() {
   // Subscriber only does serialized messages
   return create_serialized_message();
 }
 
 std::shared_ptr<rclcpp::SerializedMessage>
-Subscription::create_serialized_message()
-{
+Subscription::create_serialized_message() {
   return std::make_shared<rclcpp::SerializedMessage>();
 }
 
-void
-Subscription::handle_message(
-  std::shared_ptr<void> & message,
-  const rclcpp::MessageInfo & message_info)
-{
+void Subscription::handle_message(std::shared_ptr<void>& message,
+                                  const rclcpp::MessageInfo& message_info) {
   handle_serialized_message(
-    std::static_pointer_cast<rclcpp::SerializedMessage>(message),
-    message_info);
+      std::static_pointer_cast<rclcpp::SerializedMessage>(message),
+      message_info);
 }
 
-void
-Subscription::handle_loaned_message(
-  void * loaned_message, const rclcpp::MessageInfo & message_info)
-{
+void Subscription::handle_loaned_message(
+    void* loaned_message, const rclcpp::MessageInfo& message_info) {
   (void)loaned_message;
   (void)message_info;
-  throw std::runtime_error("handle_loaned_message() not supported by drake_ros_core");
+  throw std::runtime_error(
+      "handle_loaned_message() not supported by drake_ros_core");
 }
 
-void
-Subscription::handle_serialized_message(
-  const std::shared_ptr<rclcpp::SerializedMessage> & message,
-  const rclcpp::MessageInfo & message_info)
-{
+void Subscription::handle_serialized_message(
+    const std::shared_ptr<rclcpp::SerializedMessage>& message,
+    const rclcpp::MessageInfo& message_info) {
   (void)message_info;
   callback_(message);
 }
 
-void
-Subscription::return_message(std::shared_ptr<void> & message)
-{
-  auto serialized_msg_ptr = std::static_pointer_cast<rclcpp::SerializedMessage>(message);
+void Subscription::return_message(std::shared_ptr<void>& message) {
+  auto serialized_msg_ptr =
+      std::static_pointer_cast<rclcpp::SerializedMessage>(message);
   return_serialized_message(serialized_msg_ptr);
 }
 
-void
-Subscription::return_serialized_message(std::shared_ptr<rclcpp::SerializedMessage> & message)
-{
+void Subscription::return_serialized_message(
+    std::shared_ptr<rclcpp::SerializedMessage>& message) {
   message.reset();
 }
 }  // namespace drake_ros_core

--- a/drake_ros_core/src/subscription.hpp
+++ b/drake_ros_core/src/subscription.hpp
@@ -14,71 +14,61 @@
 #ifndef SUBSCRIPTION_HPP_
 #define SUBSCRIPTION_HPP_
 
-#include <rmw/serialized_message.h>
-#include <rosidl_runtime_c/message_type_support_struct.h>
-
 #include <memory>
 #include <string>
 
 #include "rclcpp/qos.hpp"
 #include "rclcpp/subscription_base.hpp"
+#include <rmw/serialized_message.h>
+#include <rosidl_runtime_c/message_type_support_struct.h>
 
-namespace drake_ros_core
-{
-class Subscription final : public rclcpp::SubscriptionBase
-{
-public:
+namespace drake_ros_core {
+class Subscription final : public rclcpp::SubscriptionBase {
+ public:
   Subscription(
-    rclcpp::node_interfaces::NodeBaseInterface * node_base,
-    const rosidl_message_type_support_t & ts,
-    const std::string & topic_name,
-    const rclcpp::QoS & qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
+      rclcpp::node_interfaces::NodeBaseInterface* node_base,
+      const rosidl_message_type_support_t& ts, const std::string& topic_name,
+      const rclcpp::QoS& qos,
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
 
   ~Subscription();
 
-protected:
+ protected:
   /// Borrow a new message.
   /** \return Shared pointer to the fresh message. */
-  std::shared_ptr<void>
-  create_message() override;
+  std::shared_ptr<void> create_message() override;
 
   /// Borrow a new serialized message
   /** \return Shared pointer to a rcl_message_serialized_t. */
-  std::shared_ptr<rclcpp::SerializedMessage>
-  create_serialized_message() override;
+  std::shared_ptr<rclcpp::SerializedMessage> create_serialized_message()
+      override;
 
   /// Check if we need to handle the message, and execute the callback if we do.
   /**
    * \param[in] message Shared pointer to the message to handle.
    * \param[in] message_info Metadata associated with this message.
    */
-  void
-  handle_message(
-    std::shared_ptr<void> & message,
-    const rclcpp::MessageInfo & message_info) override;
+  void handle_message(std::shared_ptr<void>& message,
+                      const rclcpp::MessageInfo& message_info) override;
 
-  void
-  handle_loaned_message(
-    void * loaned_message, const rclcpp::MessageInfo & message_info) override;
+  void handle_loaned_message(void* loaned_message,
+                             const rclcpp::MessageInfo& message_info) override;
 
   // TODO(hidmic): use override keyword when support for ROS Galactic is dropped
-  virtual void
-  handle_serialized_message(
-    const std::shared_ptr<rclcpp::SerializedMessage> & message,
-    const rclcpp::MessageInfo & message_info);
+  virtual void handle_serialized_message(
+      const std::shared_ptr<rclcpp::SerializedMessage>& message,
+      const rclcpp::MessageInfo& message_info);
 
   /// Return the message borrowed in create_message.
   /** \param[in] message Shared pointer to the returned message. */
-  void
-  return_message(std::shared_ptr<void> & message) override;
+  void return_message(std::shared_ptr<void>& message) override;
 
   /// Return the message borrowed in create_serialized_message.
   /** \param[in] message Shared pointer to the returned message. */
-  void
-  return_serialized_message(std::shared_ptr<rclcpp::SerializedMessage> & message) override;
+  void return_serialized_message(
+      std::shared_ptr<rclcpp::SerializedMessage>& message) override;
 
-private:
+ private:
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback_;
 };
 }  // namespace drake_ros_core

--- a/drake_ros_core/test/test_drake_ros.cpp
+++ b/drake_ros_core/test/test_drake_ros.cpp
@@ -12,31 +12,28 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <gtest/gtest.h>
-
-#include <rclcpp/rclcpp.hpp>
-
 #include <memory>
 #include <utility>
 #include <vector>
+
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
 
 #include "drake_ros_core/drake_ros.hpp"
 
 using drake_ros_core::DrakeRos;
 
-TEST(DrakeRos, default_construct)
-{
+TEST(DrakeRos, default_construct) {
   EXPECT_NO_THROW(std::make_unique<DrakeRos>());
 }
 
-TEST(DrakeRos, local_context)
-{
+TEST(DrakeRos, local_context) {
   auto context = std::make_shared<rclcpp::Context>();
   rclcpp::NodeOptions node_options;
   node_options.context(context);
 
   auto drake_ros = std::make_unique<DrakeRos>("local_ctx_node", node_options);
-  (void) drake_ros;
+  (void)drake_ros;
 
   // Should not have initialized global context
   EXPECT_FALSE(rclcpp::contexts::get_global_default_context()->is_valid());

--- a/drake_ros_core/test/test_pub_sub.cpp
+++ b/drake_ros_core/test/test_pub_sub.cpp
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <drake/systems/analysis/simulator.h>
-#include <drake/systems/framework/diagram_builder.h>
-#include <gtest/gtest.h>
-
-#include <rclcpp/rclcpp.hpp>
-#include <test_msgs/msg/basic_types.hpp>
-
 #include <memory>
 #include <utility>
 #include <vector>
+
+#include <drake/systems/analysis/simulator.h>
+#include <drake/systems/framework/diagram_builder.h>
+#include <gtest/gtest.h>
+#include <rclcpp/rclcpp.hpp>
+#include <test_msgs/msg/basic_types.hpp>
 
 #include "drake_ros_core/drake_ros.hpp"
 #include "drake_ros_core/ros_interface_system.hpp"
@@ -41,40 +40,42 @@ TEST(Integration, sub_to_pub) {
   rclcpp::QoS qos{rclcpp::KeepLast(num_msgs)};
   qos.transient_local().reliable();
 
-  auto sys_ros_interface = builder.AddSystem<RosInterfaceSystem>(std::make_unique<DrakeRos>());
-  auto sys_sub = builder.AddSystem(
-    RosSubscriberSystem::Make<test_msgs::msg::BasicTypes>(
-      "in", qos, sys_ros_interface->get_ros_interface()));
-  auto sys_pub = builder.AddSystem(
-    RosPublisherSystem::Make<test_msgs::msg::BasicTypes>(
-      "out", qos, sys_ros_interface->get_ros_interface()));
+  auto sys_ros_interface =
+      builder.AddSystem<RosInterfaceSystem>(std::make_unique<DrakeRos>());
+  auto sys_sub =
+      builder.AddSystem(RosSubscriberSystem::Make<test_msgs::msg::BasicTypes>(
+          "in", qos, sys_ros_interface->get_ros_interface()));
+  auto sys_pub =
+      builder.AddSystem(RosPublisherSystem::Make<test_msgs::msg::BasicTypes>(
+          "out", qos, sys_ros_interface->get_ros_interface()));
 
   builder.Connect(sys_sub->get_output_port(0), sys_pub->get_input_port(0));
 
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
 
-  auto simulator =
-    std::make_unique<drake::systems::Simulator<double>>(*diagram, std::move(context));
+  auto simulator = std::make_unique<drake::systems::Simulator<double>>(
+      *diagram, std::move(context));
   simulator->set_target_realtime_rate(1.0);
   simulator->Initialize();
 
-  auto & simulator_context = simulator->get_mutable_context();
+  auto& simulator_context = simulator->get_mutable_context();
 
-  // Don't need to rclcpp::init because DrakeRos uses global rclcpp::Context by default
+  // Don't need to rclcpp::init because DrakeRos uses global rclcpp::Context by
+  // default
   auto node = rclcpp::Node::make_shared("sub_to_pub");
 
   // Create publisher talking to subscriber system.
-  auto publisher = node->create_publisher<test_msgs::msg::BasicTypes>("in", qos);
+  auto publisher =
+      node->create_publisher<test_msgs::msg::BasicTypes>("in", qos);
 
   // Create subscription listening to publisher system
   std::vector<std::unique_ptr<test_msgs::msg::BasicTypes>> rx_msgs;
-  auto rx_callback = [&](std::unique_ptr<test_msgs::msg::BasicTypes> msg)
-    {
-      rx_msgs.push_back(std::move(msg));
-    };
-  auto subscription =
-    node->create_subscription<test_msgs::msg::BasicTypes>("out", qos, rx_callback);
+  auto rx_callback = [&](std::unique_ptr<test_msgs::msg::BasicTypes> msg) {
+    rx_msgs.push_back(std::move(msg));
+  };
+  auto subscription = node->create_subscription<test_msgs::msg::BasicTypes>(
+      "out", qos, rx_callback);
 
   // Send messages into the drake system
   for (size_t p = 0; p < num_msgs; ++p) {
@@ -84,7 +85,8 @@ TEST(Integration, sub_to_pub) {
   const int timeout_sec = 5;
   const int spins_per_sec = 10;
   const float time_delta = 1.0f / spins_per_sec;
-  for (int i = 0; i < timeout_sec * spins_per_sec && rx_msgs.size() < num_msgs; ++i) {
+  for (int i = 0; i < timeout_sec * spins_per_sec && rx_msgs.size() < num_msgs;
+       ++i) {
     rclcpp::spin_some(node);
     simulator->AdvanceTo(simulator_context.get_time() + time_delta);
   }


### PR DESCRIPTION
Closes #15. Precisely what the title says. This patch configures `ament_cpplint` and `ament_clang_format` linters to match [drake](https://github.com/RobotLocomotion/drake)'s style (pulling in their configuration).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/16)
<!-- Reviewable:end -->
