### PR TITLE
Don't install test messages in CI dockerfile

### DIFF
--- a/tools/containers/drake_ros_core.Dockerfile
+++ b/tools/containers/drake_ros_core.Dockerfile
@@ -28,9 +28,7 @@ COPY /${PACKAGE_NAME} ${WORKSPACE}/src/${PACKAGE_NAME}
 WORKDIR ${WORKSPACE}
 
 # install src Debian dependencies
-# TODO: Determine why test-msgs package needs to be installed manually.
 RUN apt-get update \
-    && apt-get install --no-install-recommends -y ros-${ROS_DISTRO}-test-msgs \
     && rosdep update \
     && rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This seems to work fine without it when building locally

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/18)
<!-- Reviewable:end -->
