### PR TITLE
[POC] Add drake_ros_introspection package

### DIFF
--- a/drake_ros_introspection/.clang-format
+++ b/drake_ros_introspection/.clang-format
@@ -1,0 +1,45 @@
+# -*- yaml -*-
+
+# Taken from RobotLocomotion/drake @ 73925c7eb71361e2e97601af4182ba54072d192a
+# This file determines clang-format's style settings; for details, refer to
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle:  Google
+
+Language: Cpp
+
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Specify the #include statement order.  This implements the order mandated by
+# the Google C++ Style Guide: related header, C headers, C++ headers, library
+# headers, and finally the project headers.
+#
+# To obtain updated lists of system headers used in the below expressions, see:
+# http://stackoverflow.com/questions/2027991/list-of-standard-header-files-in-c-and-c/2029106#2029106.
+IncludeCategories:
+  # Spacers used by drake/tools/formatter.py.
+  - Regex:    '^<clang-format-priority-15>$'
+    Priority: 15
+  - Regex:    '^<clang-format-priority-25>$'
+    Priority: 25
+  - Regex:    '^<clang-format-priority-35>$'
+    Priority: 35
+  - Regex:    '^<clang-format-priority-45>$'
+    Priority: 45
+  # C system headers.
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+    Priority: 20
+  # C++ system headers (as of C++17).
+  - Regex:    '^[<"](algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
+    Priority: 30
+  # Other libraries' h files (with angles).
+  - Regex:    '^<'
+    Priority: 40
+  # Your project's h files.
+  - Regex:    '^"drake_ros_core'
+    Priority: 50
+  # Other libraries' h files (with quotes).
+  - Regex:    '^"'
+    Priority: 40

--- a/drake_ros_introspection/CMakeLists.txt
+++ b/drake_ros_introspection/CMakeLists.txt
@@ -1,0 +1,61 @@
+cmake_minimum_required(VERSION 3.10)
+project(drake_ros_introspection)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+find_package(ament_cmake_ros REQUIRED)
+find_package(drake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+
+add_library(drake_ros_introspection INTERFACE)
+target_include_directories(drake_ros_introspection
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
+)
+
+add_executable(introspection_demo src/introspection_demo.cc)
+target_link_libraries(introspection_demo
+  drake_ros_introspection drake::drake
+  rclcpp::rclcpp ${std_msgs_TARGETS})
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS introspection_demo
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  TARGETS drake_ros_introspection
+  EXPORT drake_ros_introspection
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_include_directories(include)
+ament_export_targets(drake_ros_introspection)
+ament_export_dependencies(drake)
+ament_export_dependencies(rclcpp)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_clang_format REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+
+  ament_clang_format(CONFIG_FILE .clang-format)
+  ament_cpplint()
+endif()
+
+ament_package()

--- a/drake_ros_introspection/CPPLINT.cfg
+++ b/drake_ros_introspection/CPPLINT.cfg
@@ -1,0 +1,64 @@
+# Taken from RobotLocomotion/drake @ 73925c7eb71361e2e97601af4182ba54072d192a
+#
+# Copyright 2016 Robot Locomotion Group @ CSAIL. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Stop searching for additional config files.
+set noparent
+
+# Disable a warning about C++ features that were not in the original
+# C++11 specification (and so might not be well-supported).  In the
+# case of Drake, our supported minimum platforms are new enough that
+# this warning is irrelevant.
+filter=-build/c++11
+
+# Drake uses `#pragma once`, not the `#ifndef FOO_H` guard.
+# https://drake.mit.edu/styleguide/cppguide.html#The__pragma_once_Guard
+filter=-build/header_guard
+filter=+build/pragma_once
+
+# Disable cpplint's include order.  We have our own via //tools:drakelint.
+filter=-build/include_order
+
+# TODO(hidmic): uncomment when ament_cpplint updates its vendored cpplint
+# version to support the following filters. Also remove corresponding NOLINT
+# codetags in sources.
+## Allow private, sibling include files.
+#filter=-build/include_subdir
+
+# We do not care about the whitespace details of a TODO comment.  It is not
+# relevant for easy grepping, and the GSG does not specify any particular
+# whitespace style.  (We *do* care what the "TODO(username)" itself looks like
+# because GSG forces a particular style there, but that formatting is covered
+# by the readability/todo rule, which we leave enabled.)
+filter=-whitespace/todo
+
+# TODO(#1805) Fix this.
+filter=-legal/copyright
+
+# Ignore code that isn't ours.
+exclude_files=third_party
+
+# It's not worth lint-gardening the documentation.
+exclude_files=doc

--- a/drake_ros_introspection/include/drake_ros_introspection/predicates.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/predicates.h
@@ -1,0 +1,18 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake_ros_introspection/predicates/declared_by.h>
+#include <drake_ros_introspection/predicates/each.h>

--- a/drake_ros_introspection/include/drake_ros_introspection/predicates/declared_by.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/predicates/declared_by.h
@@ -1,0 +1,104 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <drake/systems/framework/system_base.h>
+
+namespace drake_ros_introspection {
+namespace predicates {
+
+namespace internal {
+
+template <typename BaseT, typename T>
+bool isinstance(const T& value) {
+  return (dynamic_cast<const BaseT*>(&value) != nullptr);
+}
+
+template <typename BaseT, typename NextBaseT, typename... BasesT, typename T>
+bool isinstance(const T& value) {
+  return isinstance<BaseT>(value) || isinstance<NextBaseT, BasesT...>(value);
+}
+
+template <template <typename> class Base, template <typename> class... Bases>
+class IsTemplateInstanceOf {
+ public:
+  template <template <typename> class Class, typename... ArgsT>
+  bool operator()(const Class<ArgsT...>& instance) const {
+    return isinstance<Base<ArgsT...>, Bases<ArgsT...>...>(instance);
+  }
+};
+
+template <typename T>
+class IsOneOf {
+ public:
+  explicit IsOneOf(std::initializer_list<T*> instances)
+      : instances_(instances) {}
+
+  bool operator()(const T& instance) const {
+    auto it = std::find(instances_.begin(), instances_.end(), &instance);
+    return it != instances_.end();
+  }
+
+ private:
+  const std::vector<T*> instances_;
+};
+
+class SystemNameMatches {
+ public:
+  explicit SystemNameMatches(std::initializer_list<std::string> names)
+      : names_(names) {}
+
+  bool operator()(const drake::systems::SystemBase& instance) const {
+    auto it = std::find(names_.begin(), names_.end(), instance.get_name());
+    if (it == names_.end()) {
+      it =
+          std::find(names_.begin(), names_.end(), instance.GetSystemPathname());
+    }
+    return it != names_.end();
+  }
+
+ private:
+  std::vector<std::string> names_;
+};
+
+}  // namespace internal
+
+template <template <typename> class System,
+          template <typename> class... Systems>
+internal::IsTemplateInstanceOf<System, Systems...> DeclaredBy() {
+  return internal::IsTemplateInstanceOf<System, Systems...>{};
+}
+
+template <typename SystemT, typename... SystemsT>
+internal::IsOneOf<const drake::systems::SystemBase> DeclaredBy(
+    const SystemT* system, const SystemsT*... systems) {
+  return internal::IsOneOf<const drake::systems::SystemBase>{system,
+                                                             systems...};
+}
+
+template <typename NameT, typename... NamesT>
+internal::SystemNameMatches DeclaredBy(const NameT& name,
+                                       const NamesT&... names) {
+  return internal::SystemNameMatches{name, names...};
+}
+
+}  // namespace predicates
+
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/predicates/each.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/predicates/each.h
@@ -1,0 +1,95 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+namespace drake_ros_introspection {
+namespace predicates {
+
+namespace internal {
+
+struct any {
+  template <typename T>
+  bool operator()(const T&) const {
+    return true;
+  }
+};
+
+}  // namespace internal
+
+class Named {
+ public:
+  explicit Named(const std::string& name) : name_(name) {}
+
+  template <class T>
+  bool operator()(const T& instance) const {
+    return instance.get_name() == name_;
+  }
+
+ private:
+  const std::string name_;
+};
+
+class AtIndex {
+ public:
+  explicit AtIndex(int index) : index_(index) {}
+
+  template <class T>
+  bool operator()(const T& instance) const {
+    return instance.get_index() == index_;
+  }
+
+ private:
+  int index_;
+};
+
+template <template <typename> class Port, typename SystemPredicateT,
+          typename IdentityPredicateT>
+class PortPredicate {
+ public:
+  PortPredicate(SystemPredicateT system_predicate,
+                IdentityPredicateT identity_predicate)
+      : system_predicate_(std::move(system_predicate)),
+        identity_predicate_(std::move(identity_predicate)) {}
+
+  template <typename T>
+  bool operator()(const Port<T>& port) const {
+    return (system_predicate_(port.get_system()) && identity_predicate_(port));
+  }
+
+ private:
+  const SystemPredicateT system_predicate_;
+  const IdentityPredicateT identity_predicate_;
+};
+
+template <template <typename> class Port, typename SystemPredicateT,
+          typename IdentityPredicateT>
+PortPredicate<Port, SystemPredicateT, IdentityPredicateT> Each(
+    SystemPredicateT&& system_predicate, IdentityPredicateT&& port_predicate) {
+  return PortPredicate<Port, SystemPredicateT, IdentityPredicateT>{
+      std::forward<SystemPredicateT>(system_predicate),
+      std::forward<IdentityPredicateT>(port_predicate)};
+}
+
+template <template <typename> class Port, typename SystemPredicateT>
+auto Each(SystemPredicateT&& identity_predicate) {
+  return Each<Port>(std::forward<SystemPredicateT>(identity_predicate),
+                    internal::any{});
+}
+
+}  // namespace predicates
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/probes.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes.h
@@ -1,0 +1,19 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake_ros_introspection/probes/port_probe.h>
+#include <drake_ros_introspection/probes/port_probe_builder.h>
+#include <drake_ros_introspection/probes/probe_interface.h>

--- a/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe.h
@@ -1,0 +1,90 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <string>
+
+#include <drake/common/drake_throw.h>
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/event_status.h>
+#include <drake/systems/framework/framework_common.h>
+#include <drake_ros_introspection/probes/probe_interface.h>
+#include <drake_ros_introspection/utilities/port_traits.h>
+#include <drake_ros_introspection/utilities/type_conversion.h>
+#include <rclcpp/rclcpp.hpp>
+
+namespace drake_ros_introspection {
+namespace probes {
+
+template <typename PortT>
+class PortProbeInterface
+    : public ProbeInterface<typename utilities::port_traits<PortT>::ScalarT> {
+ public:
+  explicit PortProbeInterface(const PortT& port) : port_(port) {}
+
+  virtual ~PortProbeInterface() = default;
+
+  const PortT& get_port() { return port_; }
+
+ private:
+  const PortT& port_;
+};
+
+template <typename PortT, typename ValueT, auto ValueConvention,
+          typename MessageT>
+class PortProbe : public PortProbeInterface<PortT> {
+ public:
+  using PortProbeInterface<PortT>::PortProbeInterface;
+
+ private:
+  using ScalarT = typename utilities::port_traits<PortT>::ScalarT;
+
+  drake::systems::EventStatus DoProbe(
+      const drake::systems::Context<ScalarT>& context) override {
+    DRAKE_THROW_UNLESS(publisher_ != nullptr);
+    if (publisher_->get_subscription_count() > 0) {
+      const PortT& port = this->get_port();
+      const drake::systems::Context<ScalarT>& subcontext =
+          port.get_system().GetMyContextFromRoot(context);
+      using convert = utilities::convert<ValueT, ValueConvention, MessageT>;
+      publisher_->publish(
+          convert::to_message(port.template Eval<ValueT>(subcontext)));
+      return drake::systems::EventStatus::Succeeded();
+    }
+    return drake::systems::EventStatus::DidNothing();
+  }
+
+  void DoConfigure(const std::shared_ptr<rclcpp::Node>& node) override {
+    static std::regex path_separator_regex{
+        drake::systems::internal::SystemMessageInterface::path_separator()};
+    static std::regex invalid_characters_regex{R"-([^\w\d_~{}/])-"};
+    const PortT& port = this->get_port();
+    std::stringstream ss;
+    ss << std::regex_replace(port.get_system().GetSystemPathname(),
+                             path_separator_regex, "/");
+    ss << "/" << port.get_name();
+    const std::string topic_name =
+        std::regex_replace(ss.str(), invalid_characters_regex, "_");
+    publisher_ = node->create_publisher<MessageT>(topic_name, 1);
+  }
+
+  std::shared_ptr<rclcpp::Publisher<MessageT>> publisher_{nullptr};
+};
+
+}  // namespace probes
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe_builder.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe_builder.h
@@ -1,0 +1,51 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <drake_ros_introspection/probes/port_probe.h>
+
+namespace drake_ros_introspection {
+namespace probes {
+
+template <typename PortT>
+class PortProbeBuilderInterface {
+ public:
+  virtual ~PortProbeBuilderInterface() = default;
+
+  std::unique_ptr<PortProbeInterface<PortT>> Build(const PortT& port) {
+    return DoBuild(port);
+  }
+
+ private:
+  virtual std::unique_ptr<PortProbeInterface<PortT>> DoBuild(
+      const PortT& port) = 0;
+};
+
+template <typename PortT, typename ValueT, auto ValueConvention,
+          typename MessageT>
+class PortProbeBuilder : public PortProbeBuilderInterface<PortT> {
+ private:
+  std::unique_ptr<PortProbeInterface<PortT>> DoBuild(
+      const PortT& port) override {
+    using PortProbeT = PortProbe<PortT, ValueT, ValueConvention, MessageT>;
+    return std::make_unique<PortProbeT>(port);
+  };
+};
+
+}  // namespace probes
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/probes/probe_interface.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes/probe_interface.h
@@ -1,0 +1,47 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/event_status.h>
+#include <rclcpp/rclcpp.hpp>
+
+namespace drake_ros_introspection {
+namespace probes {
+
+template <typename T>
+class ProbeInterface {
+ public:
+  virtual ~ProbeInterface() = default;
+
+  void Configure(const std::shared_ptr<rclcpp::Node>& node) {
+    return this->DoConfigure(node);
+  }
+
+  drake::systems::EventStatus Probe(const drake::systems::Context<T>& context) {
+    return this->DoProbe(context);
+  }
+
+ private:
+  virtual drake::systems::EventStatus DoProbe(
+      const drake::systems::Context<T>& context) = 0;
+
+  virtual void DoConfigure(const std::shared_ptr<rclcpp::Node>&) {}
+};
+
+}  // namespace probes
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/rules.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/rules.h
@@ -1,0 +1,17 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake_ros_introspection/rules/port_probing_rule.h>

--- a/drake_ros_introspection/include/drake_ros_introspection/rules/port_probing_rule.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/rules/port_probing_rule.h
@@ -1,0 +1,85 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include <drake/common/value.h>
+#include <drake_ros_introspection/probes/port_probe_builder.h>
+#include <drake_ros_introspection/utilities/port_traits.h>
+#include <drake_ros_introspection/utilities/type_conversion.h>
+
+namespace drake_ros_introspection {
+namespace rules {
+
+template <typename PortT>
+struct PortProbingRule {
+  std::function<bool(const PortT&)> matches;
+  std::unique_ptr<probes::PortProbeBuilderInterface<PortT>> builder{};
+};
+
+template <typename PortT, typename ValueT, auto ValueTConvention>
+class PortProbingRuleWriter {
+ public:
+  explicit PortProbingRuleWriter(PortProbingRule<PortT>& rule) : rule_(rule) {}
+
+  template <typename MessageT>
+  void Publish() {
+    using PortProbeBuilderT =
+        probes::PortProbeBuilder<PortT, ValueT, ValueTConvention, MessageT>;
+    rule_.builder = std::make_unique<PortProbeBuilderT>();
+  }
+
+ private:
+  PortProbingRule<PortT>& rule_;
+};
+
+template <typename PortT>
+class AbstractPortProbingRuleWriter {
+ public:
+  explicit AbstractPortProbingRuleWriter(PortProbingRule<PortT>& rule)
+      : rule_(rule) {}
+
+  template <typename ValueT,
+            auto ValueTConvention = utilities::BuiltinTypeConventions::Default>
+  PortProbingRuleWriter<PortT, ValueT, ValueTConvention> Expect() {
+    return PortProbingRuleWriter<PortT, ValueT, ValueTConvention>(rule_);
+  }
+
+  template <template <typename> typename Value,
+            auto ValueConvention = utilities::BuiltinTypeConventions::Default,
+            typename ScalarT = typename utilities::port_traits<PortT>::ScalarT>
+  PortProbingRuleWriter<PortT, Value<ScalarT>, ValueConvention> Expect() {
+    return Expect<Value<ScalarT>, ValueConvention>();
+  }
+
+  template <typename MessageT>
+  void Publish() {
+    using ValueT = drake::AbstractValue;
+    constexpr auto ValueTConvention =
+        utilities::BuiltinTypeConventions::Default;
+    using PortProbeBuilderT =
+        probes::PortProbeBuilder<PortT, ValueT, ValueTConvention, MessageT>;
+    rule_.builder = std::make_unique<PortProbeBuilderT>();
+  }
+
+ private:
+  PortProbingRule<PortT>& rule_;
+};
+
+}  // namespace rules
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor.h
@@ -1,0 +1,55 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/event_status.h>
+#include <drake_ros_introspection/probes/probe_interface.h>
+
+namespace drake_ros_introspection {
+
+template <typename T>
+class SimulatorMonitor {
+ public:
+  explicit SimulatorMonitor(
+      std::vector<std::unique_ptr<probes::ProbeInterface<T>>> probes)
+      : probes_(std::move(probes)) {}
+
+  void Configure(const std::shared_ptr<rclcpp::Node>& node) {
+    for (auto& probe : probes_) {
+      probe->Configure(node);
+    }
+  }
+
+  operator std::function<
+      drake::systems::EventStatus(const drake::systems::Context<T>&)>() {
+    return [this](const drake::systems::Context<T>& context) {
+      auto status = drake::systems::EventStatus::DidNothing();
+      for (auto& probe : probes_) {
+        status.KeepMoreSevere(probe->Probe(context));
+      }
+      return status;
+    };
+  }
+
+ private:
+  std::vector<std::unique_ptr<probes::ProbeInterface<T>>> probes_;
+};
+
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor_builder.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor_builder.h
@@ -1,0 +1,120 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <drake/systems/framework/diagram.h>
+#include <drake/systems/framework/input_port.h>
+#include <drake/systems/framework/output_port.h>
+#include <drake/systems/framework/system.h>
+#include <drake/systems/framework/system_visitor.h>
+#include <drake_ros_introspection/probes/probe_interface.h>
+#include <drake_ros_introspection/rules/port_probing_rule.h>
+#include <drake_ros_introspection/simulator_monitor.h>
+
+namespace drake_ros_introspection {
+
+template <typename T>
+class SimulatorMonitorBuilder {
+ public:
+  rules::AbstractPortProbingRuleWriter<drake::systems::InputPort<T>> For(
+      std::function<bool(const drake::systems::InputPort<T>&)> matcher) {
+    blueprint_.input_port_probing_rules.push_back({std::move(matcher)});
+    return rules::AbstractPortProbingRuleWriter<drake::systems::InputPort<T>>(
+        blueprint_.input_port_probing_rules.back());
+  }
+
+  rules::AbstractPortProbingRuleWriter<drake::systems::OutputPort<T>> For(
+      std::function<bool(const drake::systems::OutputPort<T>&)> matcher) {
+    blueprint_.output_port_probing_rules.push_back({std::move(matcher)});
+    return rules::AbstractPortProbingRuleWriter<drake::systems::OutputPort<T>>(
+        blueprint_.output_port_probing_rules.back());
+  }
+
+  SimulatorMonitor<T> Build(const drake::systems::System<T>& system) {
+    Worker worker{blueprint_};
+    system.Accept(&worker);
+    return worker.YieldOutput();
+  }
+
+ private:
+  struct Blueprint {
+    using InputPortProbingRule =
+        rules::PortProbingRule<drake::systems::InputPort<T>>;
+    std::vector<InputPortProbingRule> input_port_probing_rules;
+
+    using OutputPortProbingRule =
+        rules::PortProbingRule<drake::systems::OutputPort<T>>;
+    std::vector<OutputPortProbingRule> output_port_probing_rules;
+  };
+
+  class Worker : public drake::systems::SystemVisitor<T> {
+   public:
+    explicit Worker(const Blueprint& blueprint) : blueprint_(blueprint) {}
+
+    void VisitSystem(const drake::systems::System<T>& system) override {
+      BuildInputPortProbes(system);
+      BuildOutputPortProbes(system);
+    }
+
+    void VisitDiagram(const drake::systems::Diagram<T>& diagram) override {
+      for (auto* system : diagram.GetSystems()) {
+        system->Accept(this);
+      }
+      VisitSystem(diagram);
+    }
+
+    SimulatorMonitor<T> YieldOutput() {
+      return SimulatorMonitor<T>{std::move(probes_)};
+    }
+
+   private:
+    void BuildInputPortProbes(const drake::systems::System<T>& system) {
+      if (!blueprint_.input_port_probing_rules.empty()) {
+        for (int i = 0; i < system.num_input_ports(); ++i) {
+          auto& input_port = system.get_input_port(i);
+          for (const auto& rule : blueprint_.input_port_probing_rules) {
+            if (rule.matches(input_port)) {
+              probes_.push_back(rule.builder->Build(input_port));
+            }
+          }
+        }
+      }
+    }
+
+    void BuildOutputPortProbes(const drake::systems::System<T>& system) {
+      for (int i = 0; i < system.num_output_ports(); ++i) {
+        auto& output_port = system.get_output_port(i);
+        for (auto& rule : blueprint_.output_port_probing_rules) {
+          if (rule.matches(output_port)) {
+            probes_.push_back(rule.builder->Build(output_port));
+          }
+        }
+      }
+    }
+
+    const Blueprint& blueprint_;
+
+    std::vector<std::unique_ptr<probes::ProbeInterface<T>>> probes_{};
+  };
+
+  Blueprint blueprint_{};
+};
+
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/utilities/port_traits.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/utilities/port_traits.h
@@ -1,0 +1,36 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake/systems/framework/input_port.h>
+#include <drake/systems/framework/output_port.h>
+
+namespace drake_ros_introspection {
+namespace utilities {
+template <typename PortT>
+struct port_traits;
+
+template <typename T>
+struct port_traits<drake::systems::InputPort<T>> {
+  using ScalarT = T;
+};
+
+template <typename T>
+struct port_traits<drake::systems::OutputPort<T>> {
+  using ScalarT = T;
+};
+
+}  // namespace utilities
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/utilities/type_conversion.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/utilities/type_conversion.h
@@ -1,0 +1,46 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <drake/common/value.h>
+
+namespace drake_ros_introspection {
+namespace utilities {
+
+template <typename ValueT, auto ValueTConvention, typename MessageT>
+struct convert;
+
+template <typename ValueT, typename MessageT>
+struct conventional_convert;
+
+enum class BuiltinTypeConventions { Default };
+
+template <typename ValueT, typename MessageT>
+struct convert<ValueT, BuiltinTypeConventions::Default, MessageT>
+    : public conventional_convert<ValueT, MessageT> {};
+
+template <typename MessageT>
+struct conventional_convert<drake::AbstractValue, MessageT> {
+  static std::unique_ptr<MessageT> to_message(
+      const drake::AbstractValue& value) {
+    return std::make_unique<MessageT>(value.get_value<MessageT>());
+  }
+};
+
+}  // namespace utilities
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/package.xml
+++ b/drake_ros_introspection/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>drake_ros_introspection</name>
+  <version>0.1.0</version>
+  <description>Drake systems introspection via ROS 2.</description>
+  <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
+  <maintainer email="ian.mcmahon@tri.global">Ian McMahon</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <depend>drake</depend>
+  <depend>rclcpp</depend>
+
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/drake_ros_introspection/src/introspection_demo.cc
+++ b/drake_ros_introspection/src/introspection_demo.cc
@@ -1,0 +1,98 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <utility>
+
+#include <drake/systems/analysis/simulator.h>
+#include <drake/systems/framework/diagram.h>
+#include <drake/systems/framework/diagram_builder.h>
+#include <drake/systems/primitives/sine.h>
+#include <drake_ros_introspection/predicates.h>
+#include <drake_ros_introspection/simulator_monitor.h>
+#include <drake_ros_introspection/simulator_monitor_builder.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float64.hpp>
+
+namespace drake_ros_introspection {
+namespace utilities {
+
+template <typename T>
+struct conventional_convert<drake::systems::BasicVector<T>,
+                            std_msgs::msg::Float64> {
+  static std::unique_ptr<std_msgs::msg::Float64> to_message(
+      const drake::systems::BasicVector<T>& value) {
+    auto message = std::make_unique<std_msgs::msg::Float64>();
+    message->data = value[0];
+    return message;
+  }
+};
+
+}  // namespace utilities
+}  // namespace drake_ros_introspection
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<rclcpp::Node>("introspection_demo_node");
+
+  drake::systems::DiagramBuilder<double> builder;
+
+  constexpr double kAmplitude = 1.;
+  constexpr double kFrequency = 1.;
+  constexpr double kPhase = 1.;
+  constexpr int kSize = 1;
+  auto source_system = builder.AddSystem<drake::systems::Sine>(
+      kAmplitude, kFrequency, kPhase, kSize);
+  source_system->set_name("sine");
+
+  std::unique_ptr<drake::systems::Diagram<double>> diagram = builder.Build();
+  diagram->set_name("introspection_demo");
+
+  auto simulator = std::make_unique<drake::systems::Simulator<double>>(
+      *diagram, diagram->CreateDefaultContext());
+  simulator->set_target_realtime_rate(1.0);
+
+  using drake_ros_introspection::SimulatorMonitor;
+  using drake_ros_introspection::SimulatorMonitorBuilder;
+  using drake_ros_introspection::predicates::DeclaredBy;
+  using drake_ros_introspection::predicates::Each;
+  SimulatorMonitorBuilder<double> simulator_monitor_builder;
+  simulator_monitor_builder
+      .For(Each<drake::systems::OutputPort>(DeclaredBy<drake::systems::Sine>()))
+      .Expect<drake::systems::BasicVector>()
+      .Publish<std_msgs::msg::Float64>();
+
+  SimulatorMonitor<double> simulator_monitor =
+      simulator_monitor_builder.Build(*diagram);
+  simulator_monitor.Configure(node);
+  simulator->set_monitor(simulator_monitor);
+
+  simulator->Initialize();
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  const drake::systems::Context<double>& simulator_context =
+      simulator->get_context();
+  while (rclcpp::ok()) {
+    simulator->AdvanceTo(simulator_context.get_time() + 0.1);
+    executor.spin_once(std::chrono::nanoseconds::zero());
+  }
+  executor.remove_node(node);
+
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This is a proof of concept of an introspection mechanism for Drake systems by exposing their data flows via ROS 2 interfaces. To do this, it constructs a `drake::systems::Simulator` monitor. At the moment, only input and output ports can be monitored using ROS 2 topics, but it can be readily extended to monitor system state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/32)
<!-- Reviewable:end -->
