### PR TITLE
Adds build env script and updates README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,62 @@ The intended function of this repository:
 ### Code style
 
 All code in this repository must comply with Drake's [code style guide](https://drake.mit.edu/code_style_guide.html).
+
+## First time setup for drake-ros
+
+### Install Drake
+Choose your desired version of Drake to install locally. `drake-nightly` is
+used as an example. Fill in the variables for your PLATFORM (Ubuntu operating
+system) and desired local directory for Drake:
+```
+PLATFORM=focal
+DRAKE_INSTALL_DIR=/path/to/desired/install/dir
+curl -o drake.tar.gz https://drake-packages.csail.mit.edu/drake/nightly/drake-latest-${PLATFORM}.tar.gz
+tar -xvzf drake.tar.gz -C $DRAKE_INSTALL_DIR
+sudo apt-get update
+sudo $DRAKE_INSTALL_DIR/share/drake/setup/install_prereqs.sh
+```
+### Install ROS2 Rolling
+Follow ROS2 instructions for the install:
+https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html
+
+It is recommend installing a minimum of the `ros-rolling-desktop` meta package.
+
+### Install drake-ros
+
+Fill in your desired drake-ros workspace folder:
+```
+DRAKE_ROS_WS=/path/to/drake_ros_ws
+mkdir -p $DRAKE_ROS_WS/src
+cd $DRAKE_ROS_WS/src
+git clone git@github.com:RobotLocomotion/drake-ros.git
+```
+Copy out the drake-ros-env.sh script to the root of your workspace:
+```
+cp $DRAKE_ROS_WS/src/drake-ros/drake-ros-env.sh $DRAKE_ROS_WS
+```
+- Note: Be sure to edit the `drake-ros-env.sh` script with your custom
+`DRAKE_INSTALL_DIR`.
+
+Source environment and install ROS dependencies:
+```
+cd $DRAKE_ROS_WS
+source drake-ros-env.sh
+rosdep update
+rosdep install --from-paths src --ignore-src --rosdistro rolling -y
+```
+
+## Building drake-ros
+
+For each build, source the drake-ros-env.sh file if you haven't already in
+this terminal, then build using colcon:
+```
+DRAKE_ROS_WS=/path/to/drake_ros_ws
+cd $DRAKE_ROS_WS
+source drake-ros-env.sh
+colcon build
+```
+Finally, source the local drake-ros workspace overlay after the build:
+```
+source $DRAKE_ROS_WS/install/setup.bash
+```

--- a/drake-ros-env.sh
+++ b/drake-ros-env.sh
@@ -1,0 +1,6 @@
+ROS_DISTRO=rolling
+DRAKE_INSTALL_DIR=/path/to/installed/drake
+source /opt/ros/$ROS_DISTRO/setup.bash
+export CMAKE_PREFIX_PATH=$CMAKE_PREFIX_PATH:$DRAKE_INSTALL_DIR/lib/cmake/drake:$AMENT_PREFIX_PATH
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$DRAKE_INSTALL_DIR/lib
+export PYTHONPATH=$PYTHONPATH:$DRAKE_INSTALL_DIR/lib/python3.8/site-packages


### PR DESCRIPTION
This environment script and updated README should make things easier for folks installing `drake-ros` for the first time. This assumes you want to use `drake-ros` from your ROS2 workspace environment.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/36)
<!-- Reviewable:end -->
