### PR TITLE
Use Rolling on Focal via tarball installed via prereqs

### DIFF
--- a/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
@@ -1,7 +1,7 @@
 cc_library(
     name = @name@,
     srcs = @srcs@,
-    hdrs = glob(["{}/**/*.*".format(x) for x in @headers@]),
+    hdrs = glob(["{}/**/*.h*".format(x) for x in @headers@]),
     includes = @includes@,
     copts = @copts@,
     defines = @defines@,

--- a/bazel_ros2_rules/ros2/resources/templates/setup.sh.in
+++ b/bazel_ros2_rules/ros2/resources/templates/setup.sh.in
@@ -2,8 +2,10 @@
 
 # Source all workspaces
 for ws in @WORKSPACES@; do
+    COLCON_CURRENT_PREFIX=$ws
     . $ws/setup.sh
 done
+unset COLCON_CURRENT_PREFIX
 
 # Setup environment
 export CMAKE_PREFIX_PATH="@CMAKE_PREFIX_PATH@:$CMAKE_PREFIX_PATH"

--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/ament_cmake.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/ament_cmake.py
@@ -229,6 +229,7 @@ def collect_ament_cmake_package_direct_properties(
                 if not os.path.exists(os.path.join(directory, name)):
                     continue
             deduplicated_include_directories.append(directory)
+        properties['include_directories'] = deduplicated_include_directories
         # Do not deduplicate link directories in case we're dealing with
         # merge installs.
 

--- a/ros2_example_bazel_installed/README.md
+++ b/ros2_example_bazel_installed/README.md
@@ -3,6 +3,10 @@
 This project builds C++ and Python examples against a system-installed
 ROS 2 Rolling binary distribution within a Bazel workspace.
 
+**Note**: At present, TRI's Drake users are on Ubuntu Focal for the medium term. 
+This project deals with that constrain by installing a ROS 2 Rolling variant
+that runs on Ubuntu Focal from a tarball. See [`setup/install_prereqs.sh`](./setup/install_prereqs.sh).
+
 For an introduction to Bazel, refer to [Getting Started with Bazel](https://docs.bazel.build/versions/master/getting-started.html).
 
 For documentation on the underlying Bazel infrastructure, refer to

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -10,7 +10,7 @@ add_bazel_ros2_rules_dependencies()
 
 load("@bazel_ros2_rules//ros2:defs.bzl", "ros2_local_repository")
 
-ROS2_DIST = "rolling"
+ROS2_DIST = "rolling-focal"
 ros2_local_repository(
     name = "ros2",
     workspaces = ["/opt/ros/{}".format(ROS2_DIST)],

--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -72,7 +72,7 @@ if ! grep "${ROS2_APT_SOURCE}" /etc/apt/sources.list.d/ros2.list; then
 fi
 # Install ROS 2 Rolling dependencies
 apt update && apt install python3-rosdep libssl-dev
-[ -d /etc/ros/rosdep ] || rosdep init
+[[ -d /etc/ros/rosdep ]] || rosdep init
 rosdep update
 rosdep install --from-paths /opt/ros/rolling-focal --ignore-src -y \
   --skip-keys "cyclonedds fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers"

--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -62,8 +62,10 @@ mkdir -p /opt/ros/rolling-focal
 tar xf /tmp/ros2-rolling-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/rolling-focal
 sed -i 's|COLCON_CURRENT_PREFIX="/opt/ros/rolling"||g' /opt/ros/rolling-focal/setup.sh  # Fix wrong chained prefix, if any
 curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key  -o /usr/share/keyrings/ros-archive-keyring.gpg
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main" | tee /etc/apt/sources.list.d/ros2.list
-
+ROS2_APT_SOURCE="deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(lsb_release -cs) main"
+if ! grep "${ROS2_APT_SOURCE}" /etc/apt/sources.list.d/ros2.list; then
+  echo ${ROS2_APT_SOURCE} | tee /etc/apt/sources.list.d/ros2.list
+fi
 # Install ROS 2 Rolling dependencies
 apt update && apt install python3-rosdep
 [ -d /etc/ros/rosdep ] || rosdep init

--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -67,7 +67,7 @@ if ! grep "${ROS2_APT_SOURCE}" /etc/apt/sources.list.d/ros2.list; then
   echo ${ROS2_APT_SOURCE} | tee /etc/apt/sources.list.d/ros2.list
 fi
 # Install ROS 2 Rolling dependencies
-apt update && apt install python3-rosdep
+apt update && apt install python3-rosdep libssl-dev
 [ -d /etc/ros/rosdep ] || rosdep init
 rosdep update
 rosdep install --from-paths /opt/ros/rolling-focal --ignore-src -y \

--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -74,6 +74,13 @@ fi
 apt update && apt install python3-rosdep libssl-dev
 [[ -d /etc/ros/rosdep ]] || rosdep init
 rosdep update
+## The list of rosdep keys that are skipped below has been taken verbatim from ROS 2 Rolling binary install docs
+## (https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Binary.html#installing-the-missing-dependencies).
+## This is necessary because:
+## - Some non-ROS packages don't always installing their package manifests
+##   (cyclonedds, fastcdr, fastrtps, urdfdom_headers)
+## - Group dependencies aren't supported everywhere and are hard-coded in
+##   some packages (rti-connext-dds-5.3.1)
 rosdep install --from-paths /opt/ros/rolling-focal --ignore-src -y \
   --skip-keys "cyclonedds fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers"
 

--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -56,6 +56,10 @@ dpkg_install_from_curl \
   67447658b8313316295cd98323dfda2a27683456a237f7a3226b68c9c6c81b3a
 
 # Install ROS 2 Rolling tarball
+## This installation step always reinstalls as both traceability and
+## persistence for ROS 2 Rolling on Focal tarballs are still in the works.
+## As this procedure is carried out primarily on CI, we can afford degraded
+## UX for the time being.
 rm -rf /opt/ros/rolling-focal /tmp/ros2-rolling-linux-focal-amd64-ci.tar.bz2
 (cd /tmp && curl -sSL -O http://repo.ros2.org/ci_archives/rolling-on-focal/ros2-rolling-linux-focal-amd64-ci.tar.bz2)
 mkdir -p /opt/ros/rolling-focal

--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -77,7 +77,7 @@ rosdep update
 ## The list of rosdep keys that are skipped below has been taken verbatim from ROS 2 Rolling binary install docs
 ## (https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Binary.html#installing-the-missing-dependencies).
 ## This is necessary because:
-## - Some non-ROS packages don't always installing their package manifests
+## - Some non-ROS packages don't always install their package manifests
 ##   (cyclonedds, fastcdr, fastrtps, urdfdom_headers)
 ## - Group dependencies aren't supported everywhere and are hard-coded in
 ##   some packages (rti-connext-dds-5.3.1)


### PR DESCRIPTION
Precisely what the title says. This patch ensures we use Rolling on Focal tarballs instead of plain Rolling debians (soon to transition to Jammy). 

Two changes and a bugfix went into `bazel_ros2_rules` to get things working. Namely:

- Constrain header files to `.h*` files in `cc_library` template invocations
- Set `$COLCON_CURRENT_PREFIX` before sourcing workspaces
- Fix an omission in `ament_cmake` package scraping.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/37)
<!-- Reviewable:end -->
