### PR TITLE
Wait for subscription to begin testing

### DIFF
--- a/drake_ros_core/test/test_pub_sub.py
+++ b/drake_ros_core/test/test_pub_sub.py
@@ -76,6 +76,14 @@ def test_nominal_case():
     direct_sub_out = direct_ros_node.create_subscription(
         BasicTypes, 'out_py', rx_callback_direct_sub_out, qos)
 
+    # Wait for the subscriber to connect
+    for i in range(1, 10):
+        if direct_pub_in.get_subscription_count() > 0:
+            break
+        rclpy.spin_once(direct_ros_node, timeout_sec=0.1)
+    else:
+        assert False, 'Timeout waiting for publisher and subscriber to connect'
+
     pub_sub_rounds = 5
     for i in range(1, pub_sub_rounds + 1):
         rx_msgs_count_before_pubsub = len(rx_msgs_direct_sub_out)


### PR DESCRIPTION
It can take some time for an asynchronous DDS implementation to initialize and connect with existing subscribers. Before beginning the round trip test, we should make sure that the ROS publisher has successfully connected to the subscriber.

This should resolve the test failure when using Fast-DSS, which is the new default RMW implementation for ROS 2 Humble. Without waiting, the first message being published from ROS seems to be lost, meaning the first message recieved from Drake is a '0', which fails the test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/47)
<!-- Reviewable:end -->
