### PR TITLE
Add suppression for cpplint in Humble

### DIFF
--- a/drake_ros_core/CPPLINT.cfg
+++ b/drake_ros_core/CPPLINT.cfg
@@ -41,11 +41,8 @@ filter=+build/pragma_once
 # Disable cpplint's include order.  We have our own via //tools:drakelint.
 filter=-build/include_order
 
-# TODO(hidmic): uncomment when ament_cpplint updates its vendored cpplint
-# version to support the following filters. Also remove corresponding NOLINT
-# codetags in sources.
-## Allow private, sibling include files.
-#filter=-build/include_subdir
+# Allow private, sibling include files.
+filter=-build/include_subdir
 
 # We do not care about the whitespace details of a TODO comment.  It is not
 # relevant for easy grepping, and the GSG does not specify any particular


### PR DESCRIPTION
The name of the rule which tracks this behavior has changed in the version of cpplint used in Humble. Unfortunately, there doesn't seem to be a single suppression that works with both Galactic and Humble cpplint.

This filter should unblock builds in Humble, while the existing suppressions mentioned in the comment should continue to work for Galactic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/48)
<!-- Reviewable:end -->
