### PR TITLE
[bazel_ros2_rules] Change include directory heuristic for rosidl_runtime_cpp

### DIFF
--- a/bazel_ros2_rules/ros2/ros2bzl/templates.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/templates.py
@@ -72,7 +72,7 @@ def configure_package_cc_library(
         if not os.path.isabs(include)]
     headers = []
     for include in local_includes:
-        if name not in pathlib.Path(include).parts
+        if name not in pathlib.Path(include).parts:
             # Assume package lives in a merged install space
             # Assume package abides to REP-122 FHS layout
             include = os.path.join(include, name)


### PR DESCRIPTION
This fixes an issue that blocks using the `:rclcpp_cc` target. The blocker is the header `rosidl_typesupport_cpp/message_type_support.hpp` cannot be found when including `rclcpp/rclcpp.hpp`.

Contrary to REP 122, [`rosidl_runtime_cpp` is provides the `rosidl_typesupport_cpp/message_type_support.hpp`](https://github.com/ros2/rosidl/tree/90c5d1cc0d7b8e26de088aa0d77de277efee005f/rosidl_runtime_cpp/include/rosidl_typesupport_cpp) header. `rclcpp` [includes that header](https://github.com/ros2/rclcpp/blob/0f58bb8700e3dcdc1465d2465f5a0160db367b3f/rclcpp/include/rclcpp/get_message_type_support_handle.hpp#L22). The generated `BUILD.bazel` only associates the target `rosidl_runtime_cpp_cc` with the headers in the `rosidl_runtime_cpp/` folder, not the `rosidl_typesupport_cpp` folder, and so the missing header isn't brought into the bazel sandbox.

This fixes the issue by taking advantage of the unique include directories ros2/ros2#1150 brings to a merged workspace. Presently the heuristic assumes the include directory is non-unique if it does not end in `package_name/include`, as would be in an isolated colcon workspace( ex: `ws/install/foobar/include`). This PR makes it assume the include directory is unique if any path segment contains the package name (ex: `ws/install/include/foobar` in a merged workspace is now considered a unique include directory). That allows the `rosidl_runtime_cpp_cc` target to be associated with all the headers in its unique include directory even in a merged workspace.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/49)
<!-- Reviewable:end -->
