### PR TITLE
Only install exec, buildtool_export, and build_export deps plus skip iceoryx_binding_c

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,7 @@ jobs:
           sudo tar xf ros2-rolling-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/rolling
           sed -i 's|/tmp/ws/install_isolated|/opt/ros/rolling|g' /opt/ros/rolling/setup.sh
           rm ros2-rolling-linux-focal-amd64-ci.tar.bz2
+          # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
           rosdep update && rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y \
             -t exec -t buildtool_export -t build_export \
             --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,8 @@ jobs:
           sed -i 's|/tmp/ws/install_isolated|/opt/ros/rolling|g' /opt/ros/rolling/setup.sh
           rm ros2-rolling-linux-focal-amd64-ci.tar.bz2
           rosdep update && rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y \
-            --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers"
+            -t exec -t buildtool_export -t build_export \
+            --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c"
 
       - name: Cope with Python 2 pollution
         run: apt-get update && apt-get install -y python-is-python3


### PR DESCRIPTION
This fixes CI

`iceoryx_binding_c` needs to be skipped for reasons explained in #50.
When installing from the archive, only the `exec`, `buildtool_export`, and `build_export` dependencies are needed. Specifying that removes an error message about some non-existance build only dependencies.

The github workflow somewhat duplicates the knowledge in `bazel_ros2_rules/ros2/compute_system_rosdeps.py`. Maybe a future enhancement could use that script in CI?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/52)
<!-- Reviewable:end -->
