### PR TITLE
Call rosdep update in install_prereqs.sh

### DIFF
--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -4,6 +4,14 @@ set -eux pipefail
 
 apt update && apt install apt-transport-https curl gnupg lsb-release cmake build-essential gettext-base coreutils
 
+as-user() {
+  if [[ -n "${SUDO_USER:+D}" ]]; then
+    sudo -u ${SUDO_USER} "$@"
+  else
+    "$@"
+  fi
+}
+
 # Install Bazel (derived from setup/ubuntu/source_distribution/install_prereqs.sh at
 # https://github.com/RobotLocomotion/drake/tree/e91e62f524788081a8fd231129b64ff80607c1dd)
 function dpkg_install_from_curl() {
@@ -65,7 +73,7 @@ if [[ -z "${ROS2_DISTRO_PREFIX:-}" ]]; then
 
   apt update && apt install python3-rosdep
   [[ -d /etc/ros/rosdep ]] || rosdep init
-  rosdep update
+  as-user rosdep update --rosdistro=rolling
 
   # TODO(hidmic): be very explicit about what installation mechanisms we allow
   # NOTE: since no ROS distributions has been sourced or specified yet,


### PR DESCRIPTION
This calls `rosdep update` automatically if it hasn't been already, which is the default state after running `ros2_example_bazel_installed/setup/install_prereqs.sh` assuming the user has never used `rosdep` before.

We can't just add `rosdep update` to `install_prereqs.sh` because `rosdep update` must be run as the non-root user.

To test what happens if the rosdep database has been initialized but not updated, delete the rosdep cache in the home directory.

```console
$ rm -rf ~/.ros/rosdep
```

To test what happens if the rosdep database has never been initialized, delete both of these folders:

```console
$ rm -rf /etc/ros/rosdep/
$ rm -rf ~/.ros/rosdep
```

@IanTheEngineer & @EricCousineau-TRI  FYI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/55)
<!-- Reviewable:end -->
