### PR TITLE
Skip Fast-DDS typesupport keys

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,7 +39,7 @@ jobs:
           # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
           rosdep update && rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y \
             -t exec -t buildtool_export -t build_export \
-            --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c"
+            --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp"
 
       - name: Cope with Python 2 pollution
         run: apt-get update && apt-get install -y python-is-python3

--- a/bazel_ros2_rules/ros2/compute_system_rosdeps.py
+++ b/bazel_ros2_rules/ros2/compute_system_rosdeps.py
@@ -20,7 +20,8 @@ import sys
 # for further reference.
 SKIPPED_ROSDEP_KEYS = {
     'cyclonedds', 'fastcdr', 'fastrtps', 'iceoryx_binding_c',
-    'rti-connext-dds-5.3.1', 'urdfdom_headers'}
+    'rti-connext-dds-5.3.1', 'urdfdom_headers',
+    'rosidl_typesupport_fastrtps_cpp', 'rosidl_typesupport_fastrtps_c'}
 
 
 def parse_arguments():


### PR DESCRIPTION
This should fix drake-ros CI. I think it was broken by ros2/rosidl_defaults/pull/20 - see this comment for more info https://github.com/ros2/rosidl_defaults/issues/21#issuecomment-1089139080

@IanTheEngineer & @EricCousineau-TRI FYI

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/56)
<!-- Reviewable:end -->
