### PR TITLE
Make TF frame name for world frame always be world

### DIFF
--- a/drake_ros_tf2/src/utilities/name_conventions.cc
+++ b/drake_ros_tf2/src/utilities/name_conventions.cc
@@ -27,6 +27,11 @@ std::string GetTfFrameName(
     const std::unordered_set<const drake::multibody::MultibodyPlant<double>*>&
         plants,
     const drake::geometry::FrameId& frame_id) {
+  // Special case: world frame is always world
+  if (frame_id == inspector.world_frame_id()) {
+    return "world";
+  }
+
   std::stringstream ss;
   for (auto* plant : plants) {
     const drake::multibody::Body<double>* body =

--- a/drake_ros_tf2/test/test_name_conventions.cc
+++ b/drake_ros_tf2/test/test_name_conventions.cc
@@ -17,6 +17,13 @@
 #include "utilities/internal_name_conventions.h"
 #include <gtest/gtest.h>
 
+#include "drake_ros_tf2/utilities/name_conventions.h"
+
+using drake::geometry::FrameId;
+using drake::multibody::ModelInstanceIndex;
+using drake::multibody::MultibodyPlant;
+using drake::systems::DiagramBuilder;
+
 TEST(NameConventions, CalcTfFrameNameWithBody) {
   // All names are present
   EXPECT_EQ("model_name/body_name/456",
@@ -70,4 +77,21 @@ TEST(NameConventions, CalcTfFrameNameWithoutBody) {
   // Frame name with only / delimiter
   EXPECT_EQ("unnamed_frame_123",
             drake_ros_tf2::internal::CalcTfFrameName("/", 123));
+}
+
+TEST(NameConventions, GetTfFrameNameWorld) {
+  DiagramBuilder<double> builder;
+
+  auto [plant, scene_graph] = AddMultibodyPlantSceneGraph(
+      &builder, std::make_unique<MultibodyPlant<double>>(0.0));
+
+  std::unordered_set<const MultibodyPlant<double>*> plants = {&plant};
+
+  // World frame is always ModelInstanceIndex 0
+  const auto world_model_index = ModelInstanceIndex{0};
+  FrameId frame_id = plant.GetBodyFrameIdOrThrow(
+      plant.GetBodyIndices(world_model_index).at(0));
+
+  EXPECT_EQ("world", drake_ros_tf2::GetTfFrameName(
+                         scene_graph.model_inspector(), plants, frame_id));
 }


### PR DESCRIPTION
This PR makes the TF frame for the world frame always be `world`. Currently the frame ends up being `WorldModelInstance/WorldBody/10`. It's not obvious to me if the ` drake::geometry::FrameId` at the end is stable. If not, it would be hard to make an RViz config.

It must have evaluated to `world` at some point in the past because the example PR uses a fixed frame of `world` already in its RViz config.

https://github.com/RobotLocomotion/drake-ros/blob/28b4920e67715eab25fe425601e8fe4529e28a69/drake_ros_examples/examples/iiwa_manipulator/iiwa_manipulator.rviz#L91

@IanTheEngineer & @EricCousineau-TRI thoughts?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/57)
<!-- Reviewable:end -->
