### PR TITLE
Determine system library dirs by asking ld and ldconfig 

### DIFF
--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -3,6 +3,7 @@ Utility functions to aid compilation and linkage configuration scraping by
 resorting to (Linux) system-wide conventions and tooling.
 """
 
+from functools import lru_cache
 import os
 import re
 import subprocess
@@ -25,24 +26,52 @@ def is_system_include(include_path):
         for path in DEFAULT_INCLUDE_DIRECTORIES)
 
 
-# Standard library files' search paths for linkers in Linux systems.
-# Useful to detect system libraries in package exported configuration.
-DEFAULT_LINK_DIRECTORIES = ['/lib', '/usr/lib', '/usr/local/lib']
+@lru_cache(maxsize=1)
+def system_link_dirs():
+    """Get standard search paths for the linker."""
+    link_dirs = set(os.environ.get('LIBRARY_PATH', '').split(':'))
+    output = subprocess.run(
+        ['ld', '--verbose'],
+        check=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        encoding='utf8'
+    ).stdout.strip()
+
+    for directory in re.findall(r'SEARCH_DIR\("=([^=]+)"\)', output):
+        link_dirs.add(directory)
+    # Filter emtpy strings
+    return tuple([d for d in link_dirs if d])
+
+
+@lru_cache(maxsize=1)
+def system_shared_lib_dirs():
+    """Get standard search paths for the dynamic runtime loader."""
+    lib_dirs = set(os.environ.get('LD_LIBRARY_PATH', '').split(':'))
+    output = subprocess.run(
+        ['ldconfig', '--verbose'],
+        check=False,  # TODO(sloretz) why does this proces have a non-zero exit
+                      # code on my system?
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        encoding='utf8'
+    ).stdout.strip()
+
+    for directory in re.findall(r'([^:\t\n]+):', output):
+        lib_dirs.add(directory)
+    # Filter emtpy strings
+    return tuple([d for d in lib_dirs if d])
 
 
 def is_system_library(library_path):
     """
     Checks whether `library_path` is in a system library directory
-    i.e. known to linkers.
+    i.e. known to the linker or dynamic loader
     """
     library_path = os.path.realpath(library_path)
     return any(
         library_path.startswith(path)
-        for path in DEFAULT_LINK_DIRECTORIES)
-
-
-LD_LIBRARY_PATHS = [
-    path for path in os.environ.get('LD_LIBRARY_PATH', '').split(':') if path]
+        for path in system_link_dirs() + system_shared_lib_dirs())
 
 
 def find_library_path(library_name, link_directories=None, link_flags=None):
@@ -66,9 +95,9 @@ def find_library_path(library_name, link_directories=None, link_flags=None):
             cmd.extend(['-L', path])
     if link_flags:
         cmd.extend(link_flags)
-    for path in LD_LIBRARY_PATHS:
+    for path in system_shared_lib_dirs():
         cmd.extend(['-L', path])
-    for path in DEFAULT_LINK_DIRECTORIES:
+    for path in system_link_dirs():
         cmd.extend(['-L', path])
     cmd.extend(['-o', os.devnull, '-l' + library_name])
     try:

--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -29,7 +29,7 @@ def is_system_include(include_path):
 @lru_cache(maxsize=1)
 def system_link_dirs():
     """Get standard search paths for the linker."""
-    link_dirs = set(os.environ.get('LIBRARY_PATH', '').split(':'))
+    link_dirs = set()
     output = subprocess.run(
         ['ld', '--verbose'],
         check=True,
@@ -47,9 +47,9 @@ def system_link_dirs():
 @lru_cache(maxsize=1)
 def system_shared_lib_dirs():
     """Get standard search paths for the dynamic runtime loader."""
-    lib_dirs = set(os.environ.get('LD_LIBRARY_PATH', '').split(':'))
+    lib_dirs = set()
     output = subprocess.run(
-        ['ldconfig', '--verbose'],
+        ['ldconfig', '-XN', '--verbose'],
         check=False,  # TODO(sloretz) why does this proces have a non-zero exit
                       # code on my system?
         stdout=subprocess.PIPE,
@@ -95,7 +95,7 @@ def find_library_path(library_name, link_directories=None, link_flags=None):
             cmd.extend(['-L', path])
     if link_flags:
         cmd.extend(link_flags)
-    for path in system_shared_lib_dirs():
+    for path in tuple(set(os.environ.get('LIBRARY_PATH', '').split(':'))):
         cmd.extend(['-L', path])
     for path in system_link_dirs():
         cmd.extend(['-L', path])

--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -88,19 +88,18 @@ def find_library_path(library_name, link_directories=None, link_flags=None):
     # Adapted from ctypes.util.find_library_path() implementation.
     pattern = r'/(?:[^\(\)\s]*/)*lib{}\.[^\(\)\s]*'.format(library_name)
 
-    cmd = ['ld', '-t']
+    paths = []
     if link_directories:
-        for path in link_directories:
-            cmd.extend(['-L', path])
+        paths.extend(link_directories)
+    paths.extend(set(os.environ.get('LIBRARY_PATH', '').split(':')))
+    paths.extend(set(os.environ.get('LD_LIBRARY_PATH', '').split(':')))
+    paths.extend(system_link_dirs())
+    paths.extend(system_shared_lib_dirs())
+
+    cmd = ['ld', '-t']
     if link_flags:
         cmd.extend(link_flags)
-    for path in set(os.environ.get('LIBRARY_PATH', '').split(':')):
-        cmd.extend(['-L', path])
-    for path in set(os.environ.get('LD_LIBRARY_PATH', '').split(':')):
-        cmd.extend(['-L', path])
-    for path in system_link_dirs():
-        cmd.extend(['-L', path])
-    for path in system_shared_lib_dirs():
+    for path in paths:
         cmd.extend(['-L', path])
     cmd.extend(['-o', os.devnull, '-l' + library_name])
     try:

--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -40,7 +40,7 @@ def system_link_dirs():
 
     for directory in re.findall(r'SEARCH_DIR\("=([^=]+)"\)', output):
         link_dirs.add(directory)
-    # Filter emtpy strings
+    # Filter empty strings
     return tuple([d for d in link_dirs if d])
 
 
@@ -58,7 +58,7 @@ def system_shared_lib_dirs():
 
     for directory in re.findall(r'([^:\t\n]+):', output):
         lib_dirs.add(directory)
-    # Filter emtpy strings
+    # Filter empty strings
     return tuple([d for d in lib_dirs if d])
 
 

--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -50,8 +50,7 @@ def system_shared_lib_dirs():
     lib_dirs = set()
     output = subprocess.run(
         ['ldconfig', '-XN', '--verbose'],
-        check=False,  # TODO(sloretz) why does this proces have a non-zero exit
-                      # code on my system?
+        check=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.DEVNULL,
         encoding='utf8'

--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -94,7 +94,7 @@ def find_library_path(library_name, link_directories=None, link_flags=None):
             cmd.extend(['-L', path])
     if link_flags:
         cmd.extend(link_flags)
-    for path in tuple(set(os.environ.get('LIBRARY_PATH', '').split(':'))):
+    for path in set(os.environ.get('LIBRARY_PATH', '').split(':')):
         cmd.extend(['-L', path])
     for path in system_link_dirs():
         cmd.extend(['-L', path])

--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -96,7 +96,11 @@ def find_library_path(library_name, link_directories=None, link_flags=None):
         cmd.extend(link_flags)
     for path in set(os.environ.get('LIBRARY_PATH', '').split(':')):
         cmd.extend(['-L', path])
+    for path in set(os.environ.get('LD_LIBRARY_PATH', '').split(':')):
+        cmd.extend(['-L', path])
     for path in system_link_dirs():
+        cmd.extend(['-L', path])
+    for path in system_shared_lib_dirs():
         cmd.extend(['-L', path])
     cmd.extend(['-o', os.devnull, '-l' + library_name])
     try:

--- a/bazel_ros2_rules/ros2/ros2bzl/templates.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/templates.py
@@ -64,7 +64,13 @@ def configure_package_cc_library(
     name, metadata, properties, dependencies, sandbox
 ):
     target_name = cc_name(name, metadata)
-    libraries = [sandbox(library) for library in properties['link_libraries']]
+    libraries = [
+        sandbox(library)
+        for library in properties['link_libraries']
+        # Assume only libraries that map to a relative path inside the
+        # sandbox need to be mentioned in BUILD.bazel
+        if not os.path.isabs(sandbox(library))
+    ]
     include_directories = [
         sandbox(include) for include in properties['include_directories']]
     local_includes = [
@@ -188,7 +194,11 @@ def configure_package_py_library(
             config.update({
                 'cc_name': c_name("_" + target_name, metadata),
                 'cc_libs': [
-                    sandbox(lib) for lib in properties['cc_libraries']],
+                    sandbox(lib) for lib in properties['cc_libraries']
+                    # Assume only libraries that  map to a relative path inside
+                    # the sandbox need to be mentioned in BUILD.bazel
+                    if not os.path.isabs(sandbox(lib))
+                ],
                 'cc_deps': cc_deps
             })
             data.append(c_label("_" + target_name, metadata))

--- a/bazel_ros2_rules/ros2/ros2bzl/templates.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/templates.py
@@ -64,13 +64,7 @@ def configure_package_cc_library(
     name, metadata, properties, dependencies, sandbox
 ):
     target_name = cc_name(name, metadata)
-    libraries = [
-        sandbox(library)
-        for library in properties['link_libraries']
-        # Assume only libraries that map to a relative path inside the
-        # sandbox need to be mentioned in BUILD.bazel
-        if not os.path.isabs(sandbox(library))
-    ]
+    libraries = [sandbox(library) for library in properties['link_libraries']]
     include_directories = [
         sandbox(include) for include in properties['include_directories']]
     local_includes = [
@@ -194,11 +188,7 @@ def configure_package_py_library(
             config.update({
                 'cc_name': c_name("_" + target_name, metadata),
                 'cc_libs': [
-                    sandbox(lib) for lib in properties['cc_libraries']
-                    # Assume only libraries that  map to a relative path inside
-                    # the sandbox need to be mentioned in BUILD.bazel
-                    if not os.path.isabs(sandbox(lib))
-                ],
+                    sandbox(lib) for lib in properties['cc_libraries']],
                 'cc_deps': cc_deps
             })
             data.append(c_label("_" + target_name, metadata))


### PR DESCRIPTION
Fixes #60

~~I don't understand the problem completely, so I'm not 100% sure this is the right fix.~~

The amdgpu driver adds a file to `/etc/ld.so.conf.d/` to specify a directory in `/opt` that should be searched by the dynamic loader when resolving a shared library's dynamic dependencies (stuff output when doing `ldd libsomelibrary.so`).~~

The CMake scraping code looks at libraries that need to be linked with a given target. Sometimes it knows it needs to link with a system shared library, and somehow it determines that library can be found in one of the folders `/etc/ld.so.conf.d`. This gets reported to code populating the templates for `BUILD.bazel`. That code tries to map the found library to a path in the sandbox, but it can't, so it leaves it as an absolute path to the library. The data is going to be populated into `srcs` and `data` which are bazel labels, and labels can't start with `/`, so the whole `BUILD.bazel` is invalid.

**Edit** There is existing code to filter system libraries, but it uses hard coded directories. This PR uses `ld` and `ldconfig` to determine what the system directories are instead.

~~This PR resolves it by making the template code filter libraries that are still absolute paths after trying to map them into the sandbox.~~


~~Parts I'm not sure about:~~
* ~~Do the libraries in `/etc/ld.so.conf.d` need to be added to the sandbox, or is `bazel` going to do that automatically?~~
* ~~How did CMake learn that a library needing to be linked against is in a folder specified in a file in `/etc/ld.so.conf.d`?~~
* ~~Where is the `sandbox()` function getting it's data from?~~

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/61)
<!-- Reviewable:end -->
