### PR TITLE
Be explicit about Apptainer/Singularity workaround

### DIFF
--- a/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/ros2bzl/scraping/system.py
@@ -58,6 +58,8 @@ def system_shared_lib_dirs():
 
     for directory in re.findall(r'([^:\t\n]+):', output):
         lib_dirs.add(directory)
+    # Workaround Singularity redirects, e.g. for `--nv`.
+    lib_dirs.add("/.singularity.d/libs")
     # Filter empty strings
     return tuple([d for d in lib_dirs if d])
 


### PR DESCRIPTION
Cherry-pick from #59 
Alternative to #65 

This resolves the issue with libraries in `/.singularity.d/libs` being included in the ros2 `BUILD.bazel` file similar to #60

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/69)
<!-- Reviewable:end -->
