### PR TITLE
Use https to download and verify CI archive checksum

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,9 @@ jobs:
       - name: Install ROS 2 Rolling on Focal
         run: |
           sudo mkdir -p /opt/ros/rolling
+          wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci-CHECKSUM
           wget -q http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci.tar.bz2
+          sha256sum -c ros2-rolling-linux-focal-amd64-ci-CHECKSUM
           sudo tar xf ros2-rolling-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/rolling
           sed -i 's|/tmp/ws/install_isolated|/opt/ros/rolling|g' /opt/ros/rolling/setup.sh
           rm ros2-rolling-linux-focal-amd64-ci.tar.bz2


### PR DESCRIPTION
We can and should continue to use http to download the CI archive if we verify the integrity using the corresponding checksum file, which we can download securely.

This adds both authenticity (via https certificate) and integrity (via sha256sum) checking for downloading the archive for CI.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/70)
<!-- Reviewable:end -->
