### PR TITLE
Remove unnecessary print from test

### DIFF
--- a/drake_ros_viz/test/test_python_bindings.py
+++ b/drake_ros_viz/test/test_python_bindings.py
@@ -94,7 +94,6 @@ class ManagedSubscription:
     def continue_spinning(self, start_time, timeout):
         if len(self._received_messages) >= self._required_message_count:
             return False
-        print('Elapsed time is {}'.format(time.monotonic_ns() - start_time))
         if (time.monotonic_ns() - start_time) > timeout:
             return False
         return True


### PR DESCRIPTION
#24 added tests to the Python bindings for visualisation, but unfortunately a debug print was left in by mistake. This PR removes the print.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/81)
<!-- Reviewable:end -->
