### PR TITLE
Make rmw_isolation_py visible

### DIFF
--- a/bazel_ros2_rules/ros2/resources/rmw_isolation/package.BUILD.bazel
+++ b/bazel_ros2_rules/ros2/resources/rmw_isolation/package.BUILD.bazel
@@ -19,6 +19,7 @@ py_library(
     # TODO(eric.cousineau, sloretz): This import path may shadow something in
     # the future.
     imports = ["."],
+    visibility = ["//visibility:public"]
 )
 
 ros_py_binary(


### PR DESCRIPTION
This makes the `rmw_isolation_py` target visible so it can be used in downstream projects.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/87)
<!-- Reviewable:end -->
