### PR TITLE
Add missing test dependency on ament_cmake_clang_format

### DIFF
--- a/drake_ros_examples/package.xml
+++ b/drake_ros_examples/package.xml
@@ -14,6 +14,7 @@
   <depend>drake_ros_viz</depend>
   <depend>std_msgs</depend>
 
+  <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 


### PR DESCRIPTION
Need this PR to build `drake_ros_examples` with Colcon: https://gist.github.com/sloretz/074541edfe098c56ff42836118d94a8d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/88)
<!-- Reviewable:end -->
