### PR TITLE
Switch from Rolling-based underlay to Humble

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,12 +32,12 @@ jobs:
       - name: Install ROS 2 Rolling on Focal
         run: |
           sudo mkdir -p /opt/ros/rolling
-          wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci-CHECKSUM
-          wget -q http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci.tar.bz2
-          sha256sum -c ros2-rolling-linux-focal-amd64-ci-CHECKSUM
-          sudo tar xf ros2-rolling-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/rolling
+          wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM
+          wget -q http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci.tar.bz2
+          sha256sum -c ros2-humble-linux-focal-amd64-ci-CHECKSUM
+          sudo tar xf ros2-humble-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/rolling
           sed -i 's|/tmp/ws/install_isolated|/opt/ros/rolling|g' /opt/ros/rolling/setup.sh
-          rm ros2-rolling-linux-focal-amd64-ci.tar.bz2
+          rm ros2-humble-linux-focal-amd64-ci.tar.bz2
           # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
           rosdep update && rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y \
             -t exec -t buildtool_export -t build_export \

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       image: robotlocomotion/drake:focal
     steps:
       - uses: ros-tooling/setup-ros@v0.2
-      - name: Install ROS 2 Rolling on Focal
+      - name: Install dependencies to build ROS packages
         run: |
           sudo mkdir -p /opt/ros/humble
           wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: galactic
-  test_against_rolling:
+  test_against_humble:
     runs-on: ubuntu-latest
     container:
       image: robotlocomotion/drake:focal
@@ -31,15 +31,15 @@ jobs:
       - uses: ros-tooling/setup-ros@v0.2
       - name: Install ROS 2 Rolling on Focal
         run: |
-          sudo mkdir -p /opt/ros/rolling
+          sudo mkdir -p /opt/ros/humble
           wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM
           wget -q http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci.tar.bz2
           sha256sum -c ros2-humble-linux-focal-amd64-ci-CHECKSUM
-          sudo tar xf ros2-humble-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/rolling
-          sed -i 's|/tmp/ws/install_isolated|/opt/ros/rolling|g' /opt/ros/rolling/setup.sh
+          sudo tar xf ros2-humble-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/humble
+          sed -i 's|/tmp/ws/install_isolated|/opt/ros/humble|g' /opt/ros/humble/setup.sh
           rm ros2-humble-linux-focal-amd64-ci.tar.bz2
           # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
-          rosdep update && rosdep install --from-paths /opt/ros/rolling/share --ignore-src -y \
+          rosdep update && rosdep install --from-paths /opt/ros/humble/share --ignore-src -y \
             -t exec -t buildtool_export -t build_export \
             --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp"
 
@@ -48,4 +48,4 @@ jobs:
       - name: Build and test all packages
         uses: ros-tooling/action-ros-ci@v0.2
         with:
-          target-ros2-distro: rolling
+          target-ros2-distro: humble

--- a/drake_ros_core/WORKSPACE
+++ b/drake_ros_core/WORKSPACE
@@ -29,11 +29,9 @@ ros2_archive(
       "rosidl_typesupport_cpp",
       "test_msgs",
     ],
-    url = "http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci.tar.bz2",
-    sha256_url = "https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci-CHECKSUM",
+    url = "http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci.tar.bz2",
+    sha256_url = "https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM",
     strip_prefix = "ros2-linux",
-    # Fix wrong chained prefix, if any
-    patch_cmds = ["sed -i 's|COLCON_CURRENT_PREFIX=\"/opt/ros/rolling\"||g' archive/setup.sh"],
 )
 
 # Depend on Drake

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -36,8 +36,8 @@ ros2_archive(
     # according to versions you want.
     # TODO(hidmic,cottsay): Make release-pinned snapshots of this repository once `drake-ros`
     # itself has versions.
-    url = "http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci.tar.bz2",
-    sha256_url = "https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-rolling-linux-focal-amd64-ci-CHECKSUM",
+    url = "http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci.tar.bz2",
+    sha256_url = "https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM",
     strip_prefix = "ros2-linux",
 )
 


### PR DESCRIPTION
The Rolling distribution changes quickly, and now that it has been released, the Humble LTS is a much more stable target that contains all of the features we need.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/89)
<!-- Reviewable:end -->
