### PR TITLE
Fix scraping of plugin libraries from the ament index

### DIFF
--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -87,6 +87,8 @@ def collect_ros_package_metadata(name, prefix):
     """
     share_directory = os.path.join(prefix, 'share', name)
     ament_index_directory = os.path.join(prefix, 'share', 'ament_index')
+    resource_index_directory = os.path.join(
+        ament_index_directory, 'resource_index')
 
     metadata = dict(
         prefix=prefix,
@@ -104,12 +106,19 @@ def collect_ros_package_metadata(name, prefix):
 
     metadata['langs'] = collect_package_langs(metadata)
 
-    path_to_plugins_description_xml = os.path.join(
-        share_directory, 'plugins_description.xml'
-    )
-    if os.path.exists(path_to_plugins_description_xml):
-        metadata.update(parse_plugins_description_xml(
-            path_to_plugins_description_xml
-        ))
+    # Find any plugins provided by this package
+    plugin_libraries = []
+    for resource_name in os.listdir(resource_index_directory)
+        if resource_name.endswith('__pluginlib_plugin'):
+            plugin_resource = os.path.join(
+                resource_index_directory, resource_name, name)
+            if os.path.exists(plugin_resource):
+                with open('plugin_resource', 'r') as fin:
+                    path_to_plugin_descriptions_xml = fin.read()
+                if os.path.exists(path_to_plugins_description_xml):
+                    plugin_libraries.extend(parse_plugins_description_xml(
+                        path_to_plugins_description_xml)['plugin_libraries'])
+    if plugin_libraries:
+        metadata['plugin_libraries'] = plugin_info
 
     return metadata

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -108,10 +108,14 @@ def collect_ros_package_metadata(name, prefix):
 
     # Find any plugins provided by this package
     plugin_libraries = []
-    for resource_name in os.listdir(resource_index_directory):
-        if resource_name.endswith('__pluginlib__plugin'):
+    for resource_type in os.listdir(resource_index_directory):
+        # Pluginlib adds this suffix to the ament index resource type
+        # https://github.com/ros/pluginlib/blob/
+        # a11ecea28a587637d51f036e0e04eb194b94abfe/pluginlib/cmake/
+        # pluginlib_package_hook.cmake#L22
+        if resource_type.endswith('__pluginlib__plugin'):
             plugin_resource = os.path.join(
-                resource_index_directory, resource_name, name)
+                resource_index_directory, resource_type, name)
             if os.path.exists(plugin_resource):
                 with open(plugin_resource, 'r') as fin:
                     path_to_desc = fin.read()

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -109,16 +109,20 @@ def collect_ros_package_metadata(name, prefix):
     # Find any plugins provided by this package
     plugin_libraries = []
     for resource_name in os.listdir(resource_index_directory):
-        if resource_name.endswith('__pluginlib_plugin'):
+        if resource_name.endswith('__pluginlib__plugin'):
             plugin_resource = os.path.join(
                 resource_index_directory, resource_name, name)
             if os.path.exists(plugin_resource):
-                with open('plugin_resource', 'r') as fin:
-                    path_to_plugin_descriptions_xml = fin.read()
-                if os.path.exists(path_to_plugins_description_xml):
+                with open(plugin_resource, 'r') as fin:
+                    path_to_desc = fin.read()
+                # Strip any trailing newline
+                path_to_desc = path_to_desc.strip()
+                if not os.path.isabs(path_to_desc):
+                    path_to_desc = os.path.join(prefix, path_to_desc)
+                if os.path.exists(path_to_desc):
                     plugin_libraries.extend(parse_plugins_description_xml(
-                        path_to_plugins_description_xml)['plugin_libraries'])
+                        path_to_desc)['plugin_libraries'])
     if plugin_libraries:
-        metadata['plugin_libraries'] = plugin_info
+        metadata['plugin_libraries'] = plugin_libraries
 
     return metadata

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -108,7 +108,7 @@ def collect_ros_package_metadata(name, prefix):
 
     # Find any plugins provided by this package
     plugin_libraries = []
-    for resource_name in os.listdir(resource_index_directory)
+    for resource_name in os.listdir(resource_index_directory):
         if resource_name.endswith('__pluginlib_plugin'):
             plugin_resource = os.path.join(
                 resource_index_directory, resource_name, name)


### PR DESCRIPTION
The current scrapping code assumes pluginlib description files are always called `plugins_description.xml`, however that's not always true. The `image_transport` package doesn't name it's plugin description this way, and that prevents loading the `Image` display plugin in RViz when using `bazel run @ros2//:rviz2`.

This fixes it by looking up the plugins provided by a package in the ament resource index.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/92)
<!-- Reviewable:end -->
