### PR TITLE
Add introspection of Drake output values as ROS topics

### DIFF
--- a/drake_ros_examples/CMakeLists.txt
+++ b/drake_ros_examples/CMakeLists.txt
@@ -14,6 +14,8 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(drake REQUIRED)
 find_package(drake_ros_core REQUIRED)
 find_package(drake_ros_viz REQUIRED)
+find_package(drake_ros_introspection REQUIRED)
+find_package(rclcpp REQUIRED)
 
 add_subdirectory(examples/iiwa_manipulator)
 add_subdirectory(examples/rs_flip_flop)

--- a/drake_ros_examples/examples/CMakeLists.txt
+++ b/drake_ros_examples/examples/CMakeLists.txt
@@ -1,0 +1,4 @@
+add_subdirectory(iiwa_manipulator)
+add_subdirectory(manipulation_station)
+add_subdirectory(rs_flip_flop)
+add_subdirectory(sine)

--- a/drake_ros_examples/examples/manipulation_station/CMakeLists.txt
+++ b/drake_ros_examples/examples/manipulation_station/CMakeLists.txt
@@ -1,0 +1,17 @@
+find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
+
+add_executable(manipulation_station manipulation_station.cpp)
+target_link_libraries(manipulation_station
+  drake::drake
+  drake_ros_core::drake_ros_core
+  drake_ros_viz::drake_ros_viz
+  rclcpp::rclcpp
+  drake_ros_introspection::drake_ros_introspection
+  ${std_msgs_TARGETS}
+  ${sensor_msgs_TARGETS})
+
+install(
+  TARGETS manipulation_station
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/drake_ros_examples/examples/manipulation_station/README.md
+++ b/drake_ros_examples/examples/manipulation_station/README.md
@@ -1,0 +1,58 @@
+# Manipulation station
+
+## Overview
+
+This sample demonstrates the use of the Drake-to-ROS connection for Drake ports.
+It uses the manipulation station sample included in Drake to provide a fairly complex system.
+The system is introspected by a SimulatorMonitor that creates two ROS topic publishers.
+One publisher provides the joint position commanded to the IIWA robot in the simulation.
+The other publisher provides the measured joint positions.
+These output values are published by the publisheres, making them accessible to ROS nodes.
+
+It publishes the following topics:
+
+* `/_/manipulation_station/iiwa_position_commanded`
+* `/_/manipulation_station/iiwa_position_measured`
+
+## How To
+
+Run the C++ `sine` executable script as explained [here](../../README.md#running).
+
+```
+ros2 run drake_ros_examples manipulation_station
+```
+
+In a separate terminal, echo one of the topics.
+
+```
+ros2 topic echo /_/manipulation_station/iiwa_position_measured`
+```
+
+You should see the joint positions output in the terminal.
+
+```
+---
+header:
+  stamp:
+    sec: 0
+    nanosec: 0
+  frame_id: ''
+name:
+- '0'
+- '1'
+- '2'
+- '3'
+- '4'
+- '5'
+- '6'
+position:
+- -1.487725015191346
+- 0.09999999384812874
+- -3.55867481091712e-08
+- -1.2000000019039663
+- 1.7087395726122562e-07
+- 1.600000018100928
+- 1.5163324676288342e-08
+velocity: []
+effort: []
+```

--- a/drake_ros_examples/examples/manipulation_station/manipulation_station.cpp
+++ b/drake_ros_examples/examples/manipulation_station/manipulation_station.cpp
@@ -50,23 +50,35 @@ using drake::examples::manipulation_station::ManipulationStation;
 namespace drake_ros_introspection {
 namespace utilities {
 
+// This is a type converter.
+// It is required to convert from the Drake type BasicVector<T>, which is the
+// type of the output port in the Drake system, to the ROS interface type
+// std_msgs::msg::Float64, which is the type that will be published over the
+// ROS topic.
+// It is a template parameterised by these two types, and provides a
+// to_message() function that receives an instance of the Drake type and
+// returns an instance the ROS interface type.
 template <typename T>
 struct conventional_convert<drake::systems::BasicVector<T>,
                             std_msgs::msg::Float64> {
   static std::unique_ptr<std_msgs::msg::Float64> to_message(
       const drake::systems::BasicVector<T>& value) {
     auto message = std::make_unique<std_msgs::msg::Float64>();
+    // Copy the data from the Drake type into the ROS message
     message->data = value[0];
     return message;
   }
 };
 
+// This type converter is used to convert a Drake BasicVector<T> into
+// a ROS sensor_msgs::msg::JointState.
 template <typename T>
 struct conventional_convert<drake::systems::BasicVector<T>,
                             sensor_msgs::msg::JointState> {
   static std::unique_ptr<sensor_msgs::msg::JointState> to_message(
       const drake::systems::BasicVector<T>& value) {
     auto message = std::make_unique<sensor_msgs::msg::JointState>();
+    // Copy the data from the Drake type into the ROS message
     for (auto ii = 0; ii < value.size(); ++ii) {
       std::stringstream joint_name;
       joint_name << ii;
@@ -81,16 +93,18 @@ struct conventional_convert<drake::systems::BasicVector<T>,
 }  // namespace drake_ros_introspection
 
 
-int main(int argc, char* argv[])
-{
+int main(int argc, char* argv[]) {
+  // Create a ROS node that will be used to create publishers
   rclcpp::init(argc, argv);
   auto node = std::make_shared<rclcpp::Node>("introspection_demo_iiwa");
 
   drake::systems::DiagramBuilder<double> builder;
 
+  // Add the Drake-ROS core system to the diagram
   auto ros_interface_system =
     builder.AddSystem<RosInterfaceSystem>(std::make_unique<DrakeRos>());
 
+  // Add a manipulation station to the diagram
   auto manipulation_station = builder.AddSystem<ManipulationStation>();
   manipulation_station->SetupClutterClearingStation();
   manipulation_station->Finalize();
@@ -101,9 +115,10 @@ int main(int argc, char* argv[])
 
   drake::VectorX<double> amplitudes =
     drake::VectorX<double>::Zero(manipulation_station->num_iiwa_joints());
-  amplitudes[0] = M_PI / 4.;  // == 45 degrees
+  amplitudes[0] = M_PI / 4.;  // = 45 degrees
   const drake::VectorX<double> frequencies =
-    drake::VectorX<double>::Constant(manipulation_station->num_iiwa_joints(), 1.);  // Hz
+    drake::VectorX<double>::Constant(
+      manipulation_station->num_iiwa_joints(), 1.);  // Hz
   const drake::VectorX<double> phases =
     drake::VectorX<double>::Zero(manipulation_station->num_iiwa_joints());
   auto variable_term = builder.AddSystem<Sine>(amplitudes, frequencies, phases);
@@ -111,6 +126,7 @@ int main(int argc, char* argv[])
   auto joint_trajectory_generator =
     builder.AddSystem<Adder>(2, manipulation_station->num_iiwa_joints());
 
+  // Connect up the joint trajectory generator and the iiwa robot
   builder.Connect(
     constant_term->get_output_port(),
     joint_trajectory_generator->get_input_port(0));
@@ -121,12 +137,11 @@ int main(int argc, char* argv[])
     joint_trajectory_generator->get_output_port(),
     manipulation_station->GetInputPort("iiwa_position"));
 
+  // Add some ROS visualisation
   auto rviz_visualizer = builder.AddSystem<RvizVisualizer>(
     ros_interface_system->get_ros_interface());
-
   rviz_visualizer->RegisterMultibodyPlant(
     &manipulation_station->get_multibody_plant());
-
   builder.Connect(
     manipulation_station->GetOutputPort("query_object"),
     rviz_visualizer->get_graph_query_port());
@@ -134,31 +149,47 @@ int main(int argc, char* argv[])
   auto diagram = builder.Build();
   auto context = diagram->CreateDefaultContext();
 
+  // Create a simulator to execute the manipulation station
   auto simulator = std::make_unique<Simulator<double>>(*diagram, std::move(context));
   simulator->set_target_realtime_rate(1.0);
 
+  // Bring in the introspection types
   using drake_ros_introspection::SimulatorMonitor;
   using drake_ros_introspection::SimulatorMonitorBuilder;
   using drake_ros_introspection::predicates::DeclaredBy;
   using drake_ros_introspection::predicates::Each;
   using drake_ros_introspection::predicates::Named;
+  // Create an instance of the type that constructs the SimulationMonitor
   SimulatorMonitorBuilder<double> simulator_monitor_builder;
+  // This set of calls is a specification that builds up a type that will
+  // receive a Drake type and publish it as a ROS interface type
   simulator_monitor_builder
+      // For each OutputPort declared by ManipulationStation with the
+      // name "iiwa_position_commanded"...
       .For(Each<drake::systems::OutputPort>(
         DeclaredBy<ManipulationStation>(),
         Named("iiwa_position_commanded")))
+      // ... receive a drake::systems::BasicVector instance...
       .Expect<drake::systems::BasicVector>()
+      // ... and publish a sensor_msgs::msg::JointState message
       .Publish<sensor_msgs::msg::JointState>();
+  // Another specification to capture another specific port
   simulator_monitor_builder
+      // For each OutputPort declared by ManipulationStation with the
+      // name "iiwa_position_measured"...
       .For(Each<drake::systems::OutputPort>(
         DeclaredBy<ManipulationStation>(),
         Named("iiwa_position_measured")))
+      // ... receive a drake::systems::BasicVector instance...
       .Expect<drake::systems::BasicVector>()
+      // ... and publish a sensor_msgs::msg::JointState message
       .Publish<sensor_msgs::msg::JointState>();
 
+  // Build the SimulationMonitor using the specification from above
   SimulatorMonitor<double> simulator_monitor =
       simulator_monitor_builder.Build(*diagram);
   simulator_monitor.Configure(node);
+  // Connect the simulator and the simulator monitor
   simulator->set_monitor(simulator_monitor);
 
   simulator->Initialize();
@@ -183,6 +214,7 @@ int main(int argc, char* argv[])
   constants.get_mutable_value()[0] = -M_PI / 4.;
 
   while (true) {
+    // Advance the simulator one step
     simulator->AdvanceTo(simulator_context.get_time() + 0.1);
   }
   return 0;

--- a/drake_ros_examples/examples/manipulation_station/manipulation_station.cpp
+++ b/drake_ros_examples/examples/manipulation_station/manipulation_station.cpp
@@ -170,9 +170,9 @@ int main(int argc, char* argv[]) {
         DeclaredBy<ManipulationStation>(),
         Named("iiwa_position_commanded")))
       // ... receive a drake::systems::BasicVector instance...
-      .Expect<drake::systems::BasicVector>()
+      .ReceiveDrakeType<drake::systems::BasicVector>()
       // ... and publish a sensor_msgs::msg::JointState message
-      .Publish<sensor_msgs::msg::JointState>();
+      .PublishRosType<sensor_msgs::msg::JointState>();
   // Another specification to capture another specific port
   simulator_monitor_builder
       // For each OutputPort declared by ManipulationStation with the
@@ -181,9 +181,9 @@ int main(int argc, char* argv[]) {
         DeclaredBy<ManipulationStation>(),
         Named("iiwa_position_measured")))
       // ... receive a drake::systems::BasicVector instance...
-      .Expect<drake::systems::BasicVector>()
+      .ReceiveDrakeType<drake::systems::BasicVector>()
       // ... and publish a sensor_msgs::msg::JointState message
-      .Publish<sensor_msgs::msg::JointState>();
+      .PublishRosType<sensor_msgs::msg::JointState>();
 
   // Build the SimulationMonitor using the specification from above
   SimulatorMonitor<double> simulator_monitor =

--- a/drake_ros_examples/examples/sine/CMakeLists.txt
+++ b/drake_ros_examples/examples/sine/CMakeLists.txt
@@ -1,0 +1,14 @@
+find_package(std_msgs REQUIRED)
+
+add_executable(sine sine.cpp)
+target_link_libraries(sine
+  drake::drake
+  drake_ros_introspection::drake_ros_introspection
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS}
+)
+
+install(
+  TARGETS sine
+  DESTINATION lib/${PROJECT_NAME}
+)

--- a/drake_ros_examples/examples/sine/README.md
+++ b/drake_ros_examples/examples/sine/README.md
@@ -1,0 +1,28 @@
+# Sine
+
+## Overview
+
+This sample demonstrates the use of the Drake-to-ROS connection for Drake ports.
+It uses a simple system that outputs a sine wave.
+The system is introspected by a SimulatorMonitor that creates a ROS topic publisher.
+The output value of the system is published by this publisher, making it accessible to ROS nodes.
+
+It publishes the following topics:
+
+* `/introspection_demo/sine/y0`
+* `/introspection_demo/sine/y1`
+* `/introspection_demo/sine/y2`
+
+## How To
+
+Run the C++ `sine` executable script as explained [here](../../README.md#running).
+
+```
+ros2 run drake_ros_examples sine
+```
+
+In a separate terminal, echo one of the topics.
+
+```
+ros2 topic echo /introspection_demo/sine/y0
+```

--- a/drake_ros_examples/examples/sine/sine.cpp
+++ b/drake_ros_examples/examples/sine/sine.cpp
@@ -29,12 +29,21 @@
 namespace drake_ros_introspection {
 namespace utilities {
 
+// This is a type converter.
+// It is required to convert from the Drake type BasicVector<T>, which is the
+// type of the output port in the Drake system, to the ROS interface type
+// std_msgs::msg::Float64, which is the type that will be published over the
+// ROS topic.
+// It is a template parameterised by these two types, and provides a
+// to_message() function that receives an instance of the Drake type and
+// returns an instance the ROS interface type.
 template <typename T>
 struct conventional_convert<drake::systems::BasicVector<T>,
                             std_msgs::msg::Float64> {
   static std::unique_ptr<std_msgs::msg::Float64> to_message(
       const drake::systems::BasicVector<T>& value) {
     auto message = std::make_unique<std_msgs::msg::Float64>();
+    // Copy the data from the Drake type into the ROS message
     message->data = value[0];
     return message;
   }
@@ -44,12 +53,13 @@ struct conventional_convert<drake::systems::BasicVector<T>,
 }  // namespace drake_ros_introspection
 
 int main(int argc, char* argv[]) {
+  // Create a ROS node that will be used to create publishers
   rclcpp::init(argc, argv);
-
   auto node = std::make_shared<rclcpp::Node>("introspection_demo_sine");
 
   drake::systems::DiagramBuilder<double> builder;
 
+  // Create a sine wave generator system
   constexpr double kAmplitude = 1.;
   constexpr double kFrequency = 1.;
   constexpr double kPhase = 1.;
@@ -58,37 +68,53 @@ int main(int argc, char* argv[]) {
       kAmplitude, kFrequency, kPhase, kSize);
   source_system->set_name("sine");
 
+  // Make a diagram to hold the sine wave generator and the ROS interfacing
+  // system
   std::unique_ptr<drake::systems::Diagram<double>> diagram = builder.Build();
   diagram->set_name("introspection_demo");
 
+  // Create a simulator to execute the sine wave generator
   auto simulator = std::make_unique<drake::systems::Simulator<double>>(
       *diagram, diagram->CreateDefaultContext());
   simulator->set_target_realtime_rate(1.0);
 
+  // Bring in the introspection types
   using drake_ros_introspection::SimulatorMonitor;
   using drake_ros_introspection::SimulatorMonitorBuilder;
   using drake_ros_introspection::predicates::DeclaredBy;
   using drake_ros_introspection::predicates::Each;
+  // Create an instance of the type that constructs the SimulationMonitor
   SimulatorMonitorBuilder<double> simulator_monitor_builder;
+  // This set of calls is a specification that builds up a type that will
+  // receive a Drake type and publish it as a ROS interface type
   simulator_monitor_builder
+      // For each OutputPort declared by drake::systems::Sine...
       .For(Each<drake::systems::OutputPort>(DeclaredBy<drake::systems::Sine>()))
+      // ... receive a drake::systems::BasicVector instance...
       .Expect<drake::systems::BasicVector>()
+      // ... and publish a std_msgs::msg::Float64 message
       .Publish<std_msgs::msg::Float64>();
 
+  // Build the SimulationMonitor using the specification from above
   SimulatorMonitor<double> simulator_monitor =
       simulator_monitor_builder.Build(*diagram);
   simulator_monitor.Configure(node);
+  // Connect the simulator and the simulator monitor
   simulator->set_monitor(simulator_monitor);
 
   simulator->Initialize();
 
+  // Make sure the node that will be publishing the data received from the
+  // Drake simulation receives execution time
   rclcpp::executors::SingleThreadedExecutor executor;
   executor.add_node(node);
 
   const drake::systems::Context<double>& simulator_context =
       simulator->get_context();
   while (rclcpp::ok()) {
+    // Advance the simulator one step
     simulator->AdvanceTo(simulator_context.get_time() + 0.1);
+    // Give the ROS node time to process any data that needs publishing
     executor.spin_once(std::chrono::nanoseconds::zero());
   }
   executor.remove_node(node);

--- a/drake_ros_examples/examples/sine/sine.cpp
+++ b/drake_ros_examples/examples/sine/sine.cpp
@@ -91,9 +91,9 @@ int main(int argc, char* argv[]) {
       // For each OutputPort declared by drake::systems::Sine...
       .For(Each<drake::systems::OutputPort>(DeclaredBy<drake::systems::Sine>()))
       // ... receive a drake::systems::BasicVector instance...
-      .Expect<drake::systems::BasicVector>()
+      .ReceiveDrakeType<drake::systems::BasicVector>()
       // ... and publish a std_msgs::msg::Float64 message
-      .Publish<std_msgs::msg::Float64>();
+      .PublishRosType<std_msgs::msg::Float64>();
 
   // Build the SimulationMonitor using the specification from above
   SimulatorMonitor<double> simulator_monitor =

--- a/drake_ros_examples/package.xml
+++ b/drake_ros_examples/package.xml
@@ -6,13 +6,17 @@
   <maintainer email="ian.mcmahon@tri.global">Ian McMahon</maintainer>
   <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
   <maintainer email="michel@ekumenlabs.com">Michel Hidalgo</maintainer>
+  <maintainer email="geoff@openrobotics.org">Michel Hidalgo</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>drake_ros_core</depend>
   <depend>drake_ros_viz</depend>
+  <depend>drake_ros_introspection</depend>
+  <depend>rclcpp</depend>
   <depend>std_msgs</depend>
+  <depend>sensor_msgs</depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_lint_auto</test_depend>

--- a/drake_ros_introspection/.clang-format
+++ b/drake_ros_introspection/.clang-format
@@ -1,0 +1,45 @@
+# -*- yaml -*-
+
+# Taken from RobotLocomotion/drake @ 73925c7eb71361e2e97601af4182ba54072d192a
+# This file determines clang-format's style settings; for details, refer to
+# http://clang.llvm.org/docs/ClangFormatStyleOptions.html
+
+BasedOnStyle:  Google
+
+Language: Cpp
+
+# Force pointers to the type for C++.
+DerivePointerAlignment: false
+PointerAlignment: Left
+
+# Specify the #include statement order.  This implements the order mandated by
+# the Google C++ Style Guide: related header, C headers, C++ headers, library
+# headers, and finally the project headers.
+#
+# To obtain updated lists of system headers used in the below expressions, see:
+# http://stackoverflow.com/questions/2027991/list-of-standard-header-files-in-c-and-c/2029106#2029106.
+IncludeCategories:
+  # Spacers used by drake/tools/formatter.py.
+  - Regex:    '^<clang-format-priority-15>$'
+    Priority: 15
+  - Regex:    '^<clang-format-priority-25>$'
+    Priority: 25
+  - Regex:    '^<clang-format-priority-35>$'
+    Priority: 35
+  - Regex:    '^<clang-format-priority-45>$'
+    Priority: 45
+  # C system headers.
+  - Regex:    '^[<"](aio|arpa/inet|assert|complex|cpio|ctype|curses|dirent|dlfcn|errno|fcntl|fenv|float|fmtmsg|fnmatch|ftw|glob|grp|iconv|inttypes|iso646|langinfo|libgen|limits|locale|math|monetary|mqueue|ndbm|netdb|net/if|netinet/in|netinet/tcp|nl_types|poll|pthread|pwd|regex|sched|search|semaphore|setjmp|signal|spawn|stdalign|stdarg|stdatomic|stdbool|stddef|stdint|stdio|stdlib|stdnoreturn|string|strings|stropts|sys/ipc|syslog|sys/mman|sys/msg|sys/resource|sys/select|sys/sem|sys/shm|sys/socket|sys/stat|sys/statvfs|sys/time|sys/times|sys/types|sys/uio|sys/un|sys/utsname|sys/wait|tar|term|termios|tgmath|threads|time|trace|uchar|ulimit|uncntrl|unistd|utime|utmpx|wchar|wctype|wordexp)\.h[">]$'
+    Priority: 20
+  # C++ system headers (as of C++17).
+  - Regex:    '^[<"](algorithm|any|array|atomic|bitset|cassert|ccomplex|cctype|cerrno|cfenv|cfloat|charconv|chrono|cinttypes|ciso646|climits|clocale|cmath|codecvt|complex|condition_variable|csetjmp|csignal|cstdalign|cstdarg|cstdbool|cstddef|cstdint|cstdio|cstdlib|cstring|ctgmath|ctime|cuchar|cwchar|cwctype|deque|exception|execution|filesystem|forward_list|fstream|functional|future|initializer_list|iomanip|ios|iosfwd|iostream|istream|iterator|limits|list|locale|map|memory|memory_resource|mutex|new|numeric|optional|ostream|queue|random|ratio|regex|scoped_allocator|set|shared_mutex|sstream|stack|stdexcept|streambuf|string|string_view|strstream|system_error|thread|tuple|type_traits|typeindex|typeinfo|unordered_map|unordered_set|utility|valarray|variant|vector)[">]$'
+    Priority: 30
+  # Other libraries' h files (with angles).
+  - Regex:    '^<'
+    Priority: 40
+  # Your project's h files.
+  - Regex:    '^"drake_ros_core'
+    Priority: 50
+  # Other libraries' h files (with quotes).
+  - Regex:    '^"'
+    Priority: 40

--- a/drake_ros_introspection/CMakeLists.txt
+++ b/drake_ros_introspection/CMakeLists.txt
@@ -1,0 +1,72 @@
+cmake_minimum_required(VERSION 3.10)
+project(drake_ros_introspection)
+
+# Default to C++17
+if(NOT CMAKE_CXX_STANDARD)
+  set(CMAKE_CXX_STANDARD 17)
+endif()
+
+if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
+  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
+endif()
+
+find_package(ament_cmake_ros REQUIRED)
+find_package(drake REQUIRED)
+find_package(rclcpp REQUIRED)
+find_package(std_msgs REQUIRED)
+find_package(drake_ros_core REQUIRED)
+find_package(drake_ros_viz REQUIRED)
+
+add_library(drake_ros_introspection INTERFACE)
+target_include_directories(drake_ros_introspection
+  INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
+    "$<INSTALL_INTERFACE:include>"
+)
+
+add_executable(introspection_demo_sine src/introspection_demo_sine.cc)
+target_link_libraries(introspection_demo_sine
+  drake_ros_introspection drake::drake
+  rclcpp::rclcpp ${std_msgs_TARGETS})
+
+add_executable(introspection_demo_iiwa src/introspection_demo_iiwa.cc)
+target_link_libraries(introspection_demo_iiwa
+  drake_ros_introspection
+  drake::drake
+  drake_ros_core::drake_ros_core
+  drake_ros_viz::drake_ros_viz
+  rclcpp::rclcpp
+  ${std_msgs_TARGETS})
+
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+
+install(
+  TARGETS introspection_demo_sine introspection_demo_iiwa
+  DESTINATION lib/${PROJECT_NAME}
+)
+
+install(
+  TARGETS drake_ros_introspection
+  EXPORT drake_ros_introspection
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
+ament_export_include_directories(include)
+ament_export_targets(drake_ros_introspection)
+ament_export_dependencies(drake)
+ament_export_dependencies(rclcpp)
+
+if(BUILD_TESTING)
+  find_package(ament_cmake_clang_format REQUIRED)
+  find_package(ament_cmake_cpplint REQUIRED)
+
+  ament_clang_format(CONFIG_FILE .clang-format)
+  ament_cpplint()
+endif()
+
+ament_package()

--- a/drake_ros_introspection/CMakeLists.txt
+++ b/drake_ros_introspection/CMakeLists.txt
@@ -13,8 +13,6 @@ endif()
 find_package(ament_cmake_ros REQUIRED)
 find_package(drake REQUIRED)
 find_package(rclcpp REQUIRED)
-find_package(std_msgs REQUIRED)
-find_package(sensor_msgs REQUIRED)
 find_package(drake_ros_core REQUIRED)
 find_package(drake_ros_viz REQUIRED)
 
@@ -25,29 +23,9 @@ target_include_directories(drake_ros_introspection
     "$<INSTALL_INTERFACE:include>"
 )
 
-add_executable(introspection_demo_sine src/introspection_demo_sine.cc)
-target_link_libraries(introspection_demo_sine
-  drake_ros_introspection drake::drake
-  rclcpp::rclcpp ${std_msgs_TARGETS})
-
-add_executable(introspection_demo_iiwa src/introspection_demo_iiwa.cc)
-target_link_libraries(introspection_demo_iiwa
-  drake_ros_introspection
-  drake::drake
-  drake_ros_core::drake_ros_core
-  drake_ros_viz::drake_ros_viz
-  rclcpp::rclcpp
-  ${std_msgs_TARGETS}
-  ${sensor_msgs_TARGETS})
-
 install(
   DIRECTORY include/
   DESTINATION include
-)
-
-install(
-  TARGETS introspection_demo_sine introspection_demo_iiwa
-  DESTINATION lib/${PROJECT_NAME}
 )
 
 install(

--- a/drake_ros_introspection/CMakeLists.txt
+++ b/drake_ros_introspection/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(ament_cmake_ros REQUIRED)
 find_package(drake REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(std_msgs REQUIRED)
+find_package(sensor_msgs REQUIRED)
 find_package(drake_ros_core REQUIRED)
 find_package(drake_ros_viz REQUIRED)
 
@@ -36,7 +37,8 @@ target_link_libraries(introspection_demo_iiwa
   drake_ros_core::drake_ros_core
   drake_ros_viz::drake_ros_viz
   rclcpp::rclcpp
-  ${std_msgs_TARGETS})
+  ${std_msgs_TARGETS}
+  ${sensor_msgs_TARGETS})
 
 install(
   DIRECTORY include/

--- a/drake_ros_introspection/CPPLINT.cfg
+++ b/drake_ros_introspection/CPPLINT.cfg
@@ -1,0 +1,64 @@
+# Taken from RobotLocomotion/drake @ 73925c7eb71361e2e97601af4182ba54072d192a
+#
+# Copyright 2016 Robot Locomotion Group @ CSAIL. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification,
+# are permitted provided that the following conditions are met:
+#
+# 1. Redistributions of source code must retain the above copyright notice,
+#    this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright notice,
+#    this list of conditions and the following disclaimer in the documentation
+#    and/or other materials provided with the distribution.
+# 3. Neither the name of the copyright holder nor the names of its contributors
+#    may be used to endorse or promote products derived from this software without
+#    specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+# OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+# SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+# OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Stop searching for additional config files.
+set noparent
+
+# Disable a warning about C++ features that were not in the original
+# C++11 specification (and so might not be well-supported).  In the
+# case of Drake, our supported minimum platforms are new enough that
+# this warning is irrelevant.
+filter=-build/c++11
+
+# Drake uses `#pragma once`, not the `#ifndef FOO_H` guard.
+# https://drake.mit.edu/styleguide/cppguide.html#The__pragma_once_Guard
+filter=-build/header_guard
+filter=+build/pragma_once
+
+# Disable cpplint's include order.  We have our own via //tools:drakelint.
+filter=-build/include_order
+
+# TODO(hidmic): uncomment when ament_cpplint updates its vendored cpplint
+# version to support the following filters. Also remove corresponding NOLINT
+# codetags in sources.
+## Allow private, sibling include files.
+#filter=-build/include_subdir
+
+# We do not care about the whitespace details of a TODO comment.  It is not
+# relevant for easy grepping, and the GSG does not specify any particular
+# whitespace style.  (We *do* care what the "TODO(username)" itself looks like
+# because GSG forces a particular style there, but that formatting is covered
+# by the readability/todo rule, which we leave enabled.)
+filter=-whitespace/todo
+
+# TODO(#1805) Fix this.
+filter=-legal/copyright
+
+# Ignore code that isn't ours.
+exclude_files=third_party
+
+# It's not worth lint-gardening the documentation.
+exclude_files=doc

--- a/drake_ros_introspection/include/drake_ros_introspection/predicates.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/predicates.h
@@ -1,0 +1,18 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake_ros_introspection/predicates/declared_by.h>
+#include <drake_ros_introspection/predicates/each.h>

--- a/drake_ros_introspection/include/drake_ros_introspection/predicates/declared_by.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/predicates/declared_by.h
@@ -1,0 +1,133 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include <drake/systems/framework/system_base.h>
+
+#include <iostream>
+
+namespace drake_ros_introspection {
+namespace predicates {
+
+namespace internal {
+
+// A function that returns true if the type of value, T, is a subclass of BaseT.
+template <typename BaseT, typename T>
+bool isinstance(const T& value) {
+  return (dynamic_cast<const BaseT*>(&value) != nullptr);
+}
+
+// A function that returns true if the type of value, T, is a subclass of BaseT, NextBaseT, or one
+// of the classes in the BasesT parameter package.
+template <typename BaseT, typename NextBaseT, typename... BasesT, typename T>
+bool isinstance(const T& value) {
+  return isinstance<BaseT>(value) || isinstance<NextBaseT, BasesT...>(value);
+}
+
+// A function object that checks if the type of an object instance is a subclass of one or more
+// classes.
+// A type closure over a list of classes.
+// This function object can handle the base classes being templates, although they must all accept
+// the same template parameters.
+template <template <typename> class Base, template <typename> class... Bases>
+class IsTemplateInstanceOf {
+ public:
+  template <template <typename> class Class, typename... ArgsT>
+  bool operator()(const Class<ArgsT...>& instance) const {
+    return isinstance<Base<ArgsT...>, Bases<ArgsT...>...>(instance);
+  }
+};
+
+// A function object that checks if a System instance is the same as a list of System instances
+// provided when the function object is instantiated.
+// A closure over System instances.
+template <typename T>
+class IsOneOf {
+ public:
+  explicit IsOneOf(std::initializer_list<T*> instances)
+      : instances_(instances) {}
+
+  bool operator()(const T& instance) const {
+    auto it = std::find(instances_.begin(), instances_.end(), &instance);
+    return it != instances_.end();
+  }
+
+ private:
+  const std::vector<T*> instances_;
+};
+
+// A function object that checks if the name of a System instance is the same as a list
+// provided when the function object is instantiated.
+// A closure over System names (as std::string instances).
+class SystemNameMatches {
+ public:
+  explicit SystemNameMatches(std::initializer_list<std::string> names)
+      : names_(names) {}
+
+  bool operator()(const drake::systems::SystemBase& instance) const {
+    auto it = std::find(names_.begin(), names_.end(), instance.get_name());
+    if (it == names_.end()) {
+      it =
+          std::find(names_.begin(), names_.end(), instance.GetSystemPathname());
+    }
+    return it != names_.end();
+  }
+
+ private:
+  std::vector<std::string> names_;
+};
+
+}  // namespace internal
+
+// Returns a function object
+// The function object has the signature bool(Object&)
+// The function object returns true if Object inherits from one of the types in the Systems list
+template <template <typename> class System,
+          template <typename> class... Systems>
+internal::IsTemplateInstanceOf<System, Systems...>
+DeclaredBy() {
+  return internal::IsTemplateInstanceOf<System, Systems...>{};
+}
+
+// Returns a function object
+// The function object has the signature bool(System&)
+// The function object returns true if System is one of the systems given in the arguments list
+// when the function object was instantiated (i.e. the arguments passed to DeclaredBy())
+template <typename SystemT, typename... SystemsT>
+internal::IsOneOf<const drake::systems::SystemBase>
+DeclaredBy(
+    const SystemT* system, const SystemsT*... systems) {
+  return internal::IsOneOf<const drake::systems::SystemBase>{system,
+                                                             systems...};
+}
+
+// Returns a function object
+// The function object has the signature bool(System&)
+// The function object returns true if System has the same name as one of the names passed in to
+// DeclaredBy()
+template <typename NameT, typename... NamesT>
+internal::SystemNameMatches
+DeclaredBy(const NameT& name, const NamesT&... names) {
+  return internal::SystemNameMatches{name, names...};
+}
+
+}  // namespace predicates
+
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/predicates/each.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/predicates/each.h
@@ -1,0 +1,127 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <string>
+#include <utility>
+
+#include <iostream>
+
+namespace drake_ros_introspection {
+namespace predicates {
+
+namespace internal {
+
+// A function object port predicate that always returns true. Use it as the IdentityPredicate to
+// match any port on a system.
+struct any {
+  template <typename T>
+  bool operator()(const T&) const {
+    return true;
+  }
+};
+
+}  // namespace internal
+
+// A function object that returns true if the provided port instance has a name matching the name
+// passed in when the function object is instantiated.
+// A closure over a port name as a std::string.
+class Named {
+ public:
+  explicit Named(const std::string& name) : name_(name) {}
+
+  template <class T>
+  bool operator()(const T& instance) const {
+    return instance.get_name() == name_;
+  }
+
+ private:
+  const std::string name_;
+};
+
+// A function object that returns true if the provided port instance is at the index on its system
+// matching the index passed in when the function object is instantiated.
+// A closure over a port index as an int.
+class AtIndex {
+ public:
+  explicit AtIndex(int index) : index_(index) {}
+
+  template <class T>
+  bool operator()(const T& instance) const {
+    return instance.get_index() == index_;
+  }
+
+ private:
+  int index_;
+};
+
+// A function object that 
+// A closure over a system predicate function object and a port identity predicate function object.
+// When instantiated it receives instances of the system predicate and port identity predicate to
+// use to check if a port matches.
+// When called it returns true if both the system predicate and the identity predicate match for
+// the port (i.e. they both return true).
+template <template <typename> class Port, typename SystemPredicateT,
+          typename IdentityPredicateT>
+class PortPredicate {
+ public:
+  PortPredicate(SystemPredicateT system_predicate,
+                IdentityPredicateT identity_predicate)
+      : system_predicate_(std::move(system_predicate)),
+        identity_predicate_(std::move(identity_predicate)) {}
+
+  template <typename T>
+  bool operator()(const Port<T>& port) const {
+    return (system_predicate_(port.get_system()) && identity_predicate_(port));
+  }
+
+ private:
+  const SystemPredicateT system_predicate_;
+  const IdentityPredicateT identity_predicate_;
+};
+
+// Returns a function object.
+// The function object has the signature bool(Port<T>&).
+// Port is the type of the input or output Drake port to call the function object on
+// SystemPredicateT is the type of the predicate that is called on the port to match the system; it
+// has the signature bool(Port<T>&).
+// IdentityPredicateT is the type of the preidcate that is called on the port to match the identity
+// of the port; it has the signature bool(Port<T>&). Available predicates are AtIndex and Named.
+// The function object returns true if both the SystemPredicateT instance and the
+// IdentityPredicateT instance return true when called and passed the Port<T> instance.
+template <template <typename> class Port, typename SystemPredicateT,
+          typename IdentityPredicateT>
+PortPredicate<Port, SystemPredicateT, IdentityPredicateT> Each(
+    SystemPredicateT&& system_predicate, IdentityPredicateT&& port_predicate) {
+  return PortPredicate<Port, SystemPredicateT, IdentityPredicateT>{
+      std::forward<SystemPredicateT>(system_predicate),
+      std::forward<IdentityPredicateT>(port_predicate)};
+}
+
+// Returns a function object (the same type as returned by the above Each definition).
+// The function object has the signature bool(Port<T>&).
+// SystemPredicateT is the type of the predicate that is called on the port to match the system; it
+// has the signature bool(Port<T>&).
+// The function object is an instance of PortPredicate where the identity predicate is an instance
+// of internal::any. This means it can match any port on a system where the system predicate
+// matches.
+template <template <typename> class Port, typename SystemPredicateT>
+auto Each(SystemPredicateT&& identity_predicate) {
+  return Each<Port>(std::forward<SystemPredicateT>(identity_predicate),
+                    internal::any{});
+}
+
+}  // namespace predicates
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/probes.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes.h
@@ -1,0 +1,19 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake_ros_introspection/probes/port_probe.h>
+#include <drake_ros_introspection/probes/port_probe_builder.h>
+#include <drake_ros_introspection/probes/probe_interface.h>

--- a/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe.h
@@ -1,0 +1,107 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <regex>
+#include <sstream>
+#include <string>
+
+#include <drake/common/drake_throw.h>
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/event_status.h>
+#include <drake/systems/framework/framework_common.h>
+#include <drake_ros_introspection/probes/probe_interface.h>
+#include <drake_ros_introspection/utilities/port_traits.h>
+#include <drake_ros_introspection/utilities/type_conversion.h>
+#include <rclcpp/rclcpp.hpp>
+
+namespace drake_ros_introspection {
+namespace probes {
+
+// The base interface for a PortProbe.
+// A PortProbe is a specialised Probe that probes Drake system ports.
+template <typename PortT>
+class PortProbeInterface
+    : public ProbeInterface<typename utilities::port_traits<PortT>::ScalarT> {
+ public:
+  // Construct a PortProbe for the provided Drake port.
+  explicit PortProbeInterface(const PortT& port) : port_(port) {}
+
+  // Subclassable
+  virtual ~PortProbeInterface() = default;
+
+  // Get the Drake port object probed by this PortProbe.
+  const PortT& get_port() { return port_; }
+
+ private:
+  const PortT& port_;
+};
+
+// An object for probing Drake system ports.
+// When configured, it will create a publisher to a topic named after the Drake port name. The
+// publisher will publish messages of type MessageT, doing so each time the probe is called by
+// Drake  (typically every simulation step).
+template <typename PortT, typename ValueT, auto ValueConvention,
+          typename MessageT>
+class PortProbe : public PortProbeInterface<PortT> {
+ public:
+  using PortProbeInterface<PortT>::PortProbeInterface;
+
+ private:
+  using ScalarT = typename utilities::port_traits<PortT>::ScalarT;
+
+  // Called (indirectly, due to the PortProbInterface) by Drake for each simulation step.
+  // This function will get the value from the context provided by drake for the port that this
+  // probe is for. It will then convert it to the ROS type using a conversion convention, and
+  // publish that ROS value.
+  drake::systems::EventStatus DoProbe(
+      const drake::systems::Context<ScalarT>& context) override {
+    DRAKE_THROW_UNLESS(publisher_ != nullptr);
+    if (publisher_->get_subscription_count() > 0) {
+      const PortT& port = this->get_port();
+      const drake::systems::Context<ScalarT>& subcontext =
+          port.get_system().GetMyContextFromRoot(context);
+      using convert = utilities::convert<ValueT, ValueConvention, MessageT>;
+      publisher_->publish(
+          convert::to_message(port.template Eval<ValueT>(subcontext)));
+      return drake::systems::EventStatus::Succeeded();
+    }
+    return drake::systems::EventStatus::DidNothing();
+  }
+
+  // Configures the PortProbe.
+  // This function will construct a ROS publisher to match the port. The topic is named based on
+  // the name of the Drake port.
+  void DoConfigure(const std::shared_ptr<rclcpp::Node>& node) override {
+    static std::regex path_separator_regex{
+        drake::systems::internal::SystemMessageInterface::path_separator()};
+    static std::regex invalid_characters_regex{R"-([^\w\d_~{}/])-"};
+    const PortT& port = this->get_port();
+    std::stringstream ss;
+    ss << std::regex_replace(port.get_system().GetSystemPathname(),
+                             path_separator_regex, "/");
+    ss << "/" << port.get_name();
+    const std::string topic_name =
+        std::regex_replace(ss.str(), invalid_characters_regex, "_");
+    publisher_ = node->create_publisher<MessageT>(topic_name, 1);
+  }
+
+  // The ROS publisher used to publish data recieved from the port.
+  std::shared_ptr<rclcpp::Publisher<MessageT>> publisher_{nullptr};
+};
+
+}  // namespace probes
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe_builder.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes/port_probe_builder.h
@@ -1,0 +1,60 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <drake_ros_introspection/probes/port_probe.h>
+
+namespace drake_ros_introspection {
+namespace probes {
+
+// The interface to a PortProbe builder object.
+// Instantiators of this interface must implement the DoBuild() private member function. This is
+// where the functionality of constructing a port probe of the necessary type should go.
+template <typename PortT>
+class PortProbeBuilderInterface {
+ public:
+  // Subclassable
+  virtual ~PortProbeBuilderInterface() = default;
+
+  // Do the port probe construction, returning an object matching PortProbeInterface
+  std::unique_ptr<PortProbeInterface<PortT>> Build(const PortT& port) {
+    return DoBuild(port);
+  }
+
+ private:
+  // Put the implementation of constructing the port probe here.
+  virtual std::unique_ptr<PortProbeInterface<PortT>> DoBuild(
+      const PortT& port) = 0;
+};
+
+// A basic port probe builder that builds objects of the PortProbe type.
+template <typename PortT, typename ValueT, auto ValueConvention,
+          typename MessageT>
+class PortProbeBuilder : public PortProbeBuilderInterface<PortT> {
+ private:
+  // Construct a PortProbe object templated on the port type, the Drake value type, the matching
+  // ROS message type, and the convention for value conversion.
+  std::unique_ptr<PortProbeInterface<PortT>> DoBuild(
+      const PortT& port) override {
+    using PortProbeT = PortProbe<PortT, ValueT, ValueConvention, MessageT>;
+    return std::make_unique<PortProbeT>(port);
+  };
+};
+
+}  // namespace probes
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/probes/probe_interface.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/probes/probe_interface.h
@@ -1,0 +1,62 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/event_status.h>
+#include <rclcpp/rclcpp.hpp>
+
+namespace drake_ros_introspection {
+namespace probes {
+
+// The interface for a probe.
+// Instatiations of this interface must implement the DoProbe() private member function. This will
+// be called by the Probe() public member function when Probe() is called by Drake during each
+// simulation step.
+// Instatiations should also implement the DoConfigure() private function if necessary. This is
+// used to set up the probe's ROS aspects, such as declaring a publisher.
+template <typename T>
+class ProbeInterface {
+ public:
+  // Subclassable (in fact, must be subclassed)
+  virtual ~ProbeInterface() = default;
+
+  // Configure the ROS aspects of the probe. For example, create a publisher.
+  void Configure(const std::shared_ptr<rclcpp::Node>& node) {
+    return this->DoConfigure(node);
+  }
+
+  // Called by Drake during simulation after each simulation step.
+  // This is used to give the probe a chance to do whatever it is that it does, such as publishing
+  // an output port's value on a ROS topic, or inputting a value received from a ROS topic.
+  drake::systems::EventStatus Probe(const drake::systems::Context<T>& context) {
+    return this->DoProbe(context);
+  }
+
+ private:
+  // Implementation of the Probe() function should be put here.
+  // This is required
+  virtual drake::systems::EventStatus DoProbe(
+      const drake::systems::Context<T>& context) = 0;
+
+  // Implementation of the Configure() function should be put here.
+  // Not essential.
+  virtual void DoConfigure(const std::shared_ptr<rclcpp::Node>&) {}
+};
+
+}  // namespace probes
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/rules.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/rules.h
@@ -1,0 +1,17 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake_ros_introspection/rules/port_probing_rule.h>

--- a/drake_ros_introspection/include/drake_ros_introspection/rules/port_probing_rule.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/rules/port_probing_rule.h
@@ -50,7 +50,7 @@ class PortProbingRuleWriter {
 
   // Call this function to add a publishing port probe to the PortProbingRule.
   template <typename MessageT>
-  void Publish() {
+  void PublishRosType() {
     using PortProbeBuilderT =
         probes::PortProbeBuilder<PortT, ValueT, ValueTConvention, MessageT>;
     rule_.builder = std::make_unique<PortProbeBuilderT>();
@@ -66,7 +66,7 @@ class PortProbingRuleWriter {
 // In other words, it adds to a PortProbingRule a port probe builder that constructs a ROS topic
 // publisher for the Drake port.
 // It can be converted into a PortProbingRuleWriter for BasicVector type Drake ports by using the
-// Expect() member function.
+// ReceiveDrakeType() member function.
 template <typename PortT>
 class AbstractPortProbingRuleWriter {
  public:
@@ -80,7 +80,7 @@ class AbstractPortProbingRuleWriter {
   template <typename ValueT,
             auto ValueTConvention = utilities::BuiltinTypeConventions::Default>
   PortProbingRuleWriter<PortT, ValueT, ValueTConvention>
-  Expect() {
+  ReceiveDrakeType() {
     return PortProbingRuleWriter<PortT, ValueT, ValueTConvention>(rule_);
   }
 
@@ -92,14 +92,14 @@ class AbstractPortProbingRuleWriter {
             auto ValueConvention = utilities::BuiltinTypeConventions::Default,
             typename ScalarT = typename utilities::port_traits<PortT>::ScalarT>
   PortProbingRuleWriter<PortT, Value<ScalarT>, ValueConvention>
-  Expect() {
-    return Expect<Value<ScalarT>, ValueConvention>();
+  ReceiveDrakeType() {
+    return ReceiveDrakeType<Value<ScalarT>, ValueConvention>();
   }
 
   // Call this function to add a publishing port probe builder to the PortProbingRule. The port
   // probe builder constructs a port probe that publishes a Drake AbstractValue.
   template <typename MessageT>
-  void Publish() {
+  void PublishRosType() {
     using ValueT = drake::AbstractValue;
     constexpr auto ValueTConvention =
         utilities::BuiltinTypeConventions::Default;

--- a/drake_ros_introspection/include/drake_ros_introspection/rules/port_probing_rule.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/rules/port_probing_rule.h
@@ -1,0 +1,116 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+
+#include <drake/common/value.h>
+#include <drake_ros_introspection/probes/port_probe_builder.h>
+#include <drake_ros_introspection/utilities/port_traits.h>
+#include <drake_ros_introspection/utilities/type_conversion.h>
+
+namespace drake_ros_introspection {
+namespace rules {
+
+// A rule for matching a Drake port.
+// Contains the predicate function object that is called (and passed an instance of the port type,
+// PortT) to check if a port matches this rule.
+// Contains an instance of a PortProbeBuilderInterface that is used to construct a port probe for
+// matching ports. This enables the use of different builders for different port types.
+template <typename PortT>
+struct PortProbingRule {
+  std::function<bool(const PortT&)> matches;
+  std::unique_ptr<probes::PortProbeBuilderInterface<PortT>> builder{};
+};
+
+// This object is used to convert a port probing rule into a publishing-type rule for Drake ports
+// that have the BasicVector type.
+// In other words, it adds to a PortProbingRule a port probe builder that constructs a ROS topic
+// publisher for the Drake port.
+template <typename PortT, typename ValueT, auto ValueTConvention>
+class PortProbingRuleWriter {
+ public:
+  // Construct the writer by passing in a builder-less PortProbingRule that already has a predicate
+  // in it.
+  explicit PortProbingRuleWriter(PortProbingRule<PortT>& rule) : rule_(rule) {}
+
+  // Call this function to add a publishing port probe to the PortProbingRule.
+  template <typename MessageT>
+  void Publish() {
+    using PortProbeBuilderT =
+        probes::PortProbeBuilder<PortT, ValueT, ValueTConvention, MessageT>;
+    rule_.builder = std::make_unique<PortProbeBuilderT>();
+  }
+
+ private:
+  // The PortProbingRule to which the builder is added.
+  PortProbingRule<PortT>& rule_;
+};
+
+// This object is used to convert a port probing rule into a publishing-type rule for Drake ports
+// that have the AbstractValue type.
+// In other words, it adds to a PortProbingRule a port probe builder that constructs a ROS topic
+// publisher for the Drake port.
+// It can be converted into a PortProbingRuleWriter for BasicVector type Drake ports by using the
+// Expect() member function.
+template <typename PortT>
+class AbstractPortProbingRuleWriter {
+ public:
+  // Construct the writer by passing in a builder-less PortProbingRule.
+  explicit AbstractPortProbingRuleWriter(PortProbingRule<PortT>& rule)
+      : rule_(rule) {}
+
+  // Convert the AbstractPortProbingRuleWriter into a PortProbingRuleWriter by expecting the Drake
+  // port to use a particular port type (typically, BasicVector).
+  // ValueT is the type of the Drake port.
+  template <typename ValueT,
+            auto ValueTConvention = utilities::BuiltinTypeConventions::Default>
+  PortProbingRuleWriter<PortT, ValueT, ValueTConvention>
+  Expect() {
+    return PortProbingRuleWriter<PortT, ValueT, ValueTConvention>(rule_);
+  }
+
+  // Convert the AbstractPortProbingRuleWriter into a PortProbingRuleWriter by expecting the Drake
+  // port to use a particular port type.
+  // Value is the Drake port type (not BasicVector or similar, but drake::systems::OutputPort or
+  // similar). The data type of that port is extracted from it using the port_traits.
+  template <template <typename> typename Value,
+            auto ValueConvention = utilities::BuiltinTypeConventions::Default,
+            typename ScalarT = typename utilities::port_traits<PortT>::ScalarT>
+  PortProbingRuleWriter<PortT, Value<ScalarT>, ValueConvention>
+  Expect() {
+    return Expect<Value<ScalarT>, ValueConvention>();
+  }
+
+  // Call this function to add a publishing port probe builder to the PortProbingRule. The port
+  // probe builder constructs a port probe that publishes a Drake AbstractValue.
+  template <typename MessageT>
+  void Publish() {
+    using ValueT = drake::AbstractValue;
+    constexpr auto ValueTConvention =
+        utilities::BuiltinTypeConventions::Default;
+    using PortProbeBuilderT =
+        probes::PortProbeBuilder<PortT, ValueT, ValueTConvention, MessageT>;
+    rule_.builder = std::make_unique<PortProbeBuilderT>();
+  }
+
+ private:
+  PortProbingRule<PortT>& rule_;
+};
+
+}  // namespace rules
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor.h
@@ -1,0 +1,61 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <drake/systems/framework/context.h>
+#include <drake/systems/framework/event_status.h>
+#include <drake_ros_introspection/probes/probe_interface.h>
+
+namespace drake_ros_introspection {
+
+// The run-time object that stores the port probes that make up a SimulatorMonitor.
+template <typename T>
+class SimulatorMonitor {
+ public:
+  // The constructor receives a list of probes, which it stores, and which will be called by Drake
+  // regularly during simulation execution.
+  explicit SimulatorMonitor(
+      std::vector<std::unique_ptr<probes::ProbeInterface<T>>> probes)
+      : probes_(std::move(probes)) {}
+
+  // Configure all the probes in this SimulatorMonitor.
+  void Configure(const std::shared_ptr<rclcpp::Node>& node) {
+    for (auto& probe : probes_) {
+      probe->Configure(node);
+    }
+  }
+
+  // Called by Drake to update the SimulatorMonitor about the status of the simulation.
+  operator std::function<
+      drake::systems::EventStatus(const drake::systems::Context<T>&)>() {
+    return [this](const drake::systems::Context<T>& context) {
+      auto status = drake::systems::EventStatus::DidNothing();
+      for (auto& probe : probes_) {
+        status.KeepMoreSevere(probe->Probe(context));
+      }
+      return status;
+    };
+  }
+
+ private:
+  // The list of port probe object instances that make up this SimulatorMonitor.
+  std::vector<std::unique_ptr<probes::ProbeInterface<T>>> probes_;
+};
+
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor_builder.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/simulator_monitor_builder.h
@@ -1,0 +1,176 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
+#include <drake/systems/framework/diagram.h>
+#include <drake/systems/framework/input_port.h>
+#include <drake/systems/framework/output_port.h>
+#include <drake/systems/framework/system.h>
+#include <drake/systems/framework/system_visitor.h>
+#include <drake_ros_introspection/probes/probe_interface.h>
+#include <drake_ros_introspection/rules/port_probing_rule.h>
+#include <drake_ros_introspection/simulator_monitor.h>
+
+#include <iostream>
+
+namespace drake_ros_introspection {
+
+// This object constructs a simulation monitor matching a system.
+// T is the type of the system. e.g. if the system is a Sine<double> then T is double.
+// There are two entry points:
+// 1. The For() functions are used to add rules to the builder that will construct port probes.
+// 2. The Build() function actually constructs the SimulatorMonitor<T> object that performs
+// monitoring of a simulation.
+template <typename T>
+class SimulatorMonitorBuilder {
+ public:
+  // Add a rule to the blueprint that is used to find matching InputPort<T>s in the relevant
+  // systems.
+  // Returns an object that can be used to access the added rule to add additional information to
+  // it, such as the Drake type used by the port or the builder that actually creates a port probe.
+  rules::AbstractPortProbingRuleWriter<drake::systems::InputPort<T>> For(
+      std::function<bool(const drake::systems::InputPort<T>&)> matcher) {
+    blueprint_.input_port_probing_rules.push_back({std::move(matcher)});
+    return rules::AbstractPortProbingRuleWriter<drake::systems::InputPort<T>>(
+        blueprint_.input_port_probing_rules.back());
+  }
+
+  // Add a rule to the blueprint that is used to find matching OutputPort<T>s in the relevant
+  // systems.
+  // Returns an object that can be used to access the added rule to add additional information to
+  // it, such as the Drake type used by the port or the builder that actually creates a port probe.
+  rules::AbstractPortProbingRuleWriter<drake::systems::OutputPort<T>> For(
+      std::function<bool(const drake::systems::OutputPort<T>&)> matcher) {
+    blueprint_.output_port_probing_rules.push_back({std::move(matcher)});
+    return rules::AbstractPortProbingRuleWriter<drake::systems::OutputPort<T>>(
+        blueprint_.output_port_probing_rules.back());
+  }
+
+  // Call this to actually create the SimulatorMonitor<T> object, once all the necessary port
+  // rules have been added to the blueprint.
+  // This will create a worker that subclasses the Drake SystemVisitor. This worker is passed to
+  // the system that is to be monitored, which causes its VisitDiagram() and VisitSystem()
+  // functions to be called. Once the entire system (or all the systems in the diagram, if that's
+  // what it is) has been visited, the SimulatorMonitor<T> instance is returned. As long as it
+  // exists, Drake will update the port probes that it contains for each step of the simulation.
+  SimulatorMonitor<T> Build(const drake::systems::System<T>& system) {
+    Worker worker{blueprint_};
+    system.Accept(&worker);
+    return worker.YieldOutput();
+  }
+
+ private:
+  // This stores the blueprint for a SimulatorMonitor. In other words, it stores the rules that are
+  // used to construct port probes for the ports of a system to be monitored.
+  // The port probes should be added to the SimulatorMonitorBuilder using the For() functions.
+  struct Blueprint {
+    using InputPortProbingRule =
+        rules::PortProbingRule<drake::systems::InputPort<T>>;
+    std::vector<InputPortProbingRule> input_port_probing_rules;
+
+    using OutputPortProbingRule =
+        rules::PortProbingRule<drake::systems::OutputPort<T>>;
+    std::vector<OutputPortProbingRule> output_port_probing_rules;
+  };
+
+  // A visitor that is given to a Drake system or diagram, and visits that system or every system
+  // in the diagram.
+  // For each system, it iterates over all the ports the system contains and checks if any of them
+  // match any of the rules stored in the blueprint that the worker is passed when it is
+  // instantiated. If a rule matches a port, a port probe is constructed for that port and stored
+  // in the worker. Yielding the result of the worker's visit to the system/diagram will return a
+  // SimulatorMonitor<T> object instance that holds those probes.
+  class Worker : public drake::systems::SystemVisitor<T> {
+   public:
+    // Constructor for the Worker object. It receives a blueprint to use when visiting the system.
+    explicit Worker(const Blueprint& blueprint) : blueprint_(blueprint) {}
+
+    // Visit a single Drake system.
+    // This iterates over all input and output ports in the system, looking for ports that match
+    // the rules contained in the blueprint so that probes can be added for each matching port.
+    void VisitSystem(const drake::systems::System<T>& system) override {
+      BuildInputPortProbes(system);
+      BuildOutputPortProbes(system);
+    }
+
+    // Visit a Drake diagram.
+    // This visits each system contained in the diagram, before visiting the diagram itself as a
+    // system. In other words, it enables recursive visiting of composed systems.
+    void VisitDiagram(const drake::systems::Diagram<T>& diagram) override {
+      for (auto* system : diagram.GetSystems()) {
+        system->Accept(this);
+      }
+      VisitSystem(diagram);
+    }
+
+    // Return a SimulatorMonitor<T> object instance containing the port probes that were
+    // constructed during the visit to the Drake system.
+    SimulatorMonitor<T> YieldOutput() {
+      return SimulatorMonitor<T>{std::move(probes_)};
+    }
+
+   private:
+    // Iterate over each input port in the system currently being visited.
+    // For each port, iterate over the InputPort probing rules stored in the blueprint and see if
+    // any match.
+    // For those that match, call the related port probe builder to build a probe, and store that
+    // probe in the input port probes list.
+    void BuildInputPortProbes(const drake::systems::System<T>& system) {
+      if (!blueprint_.input_port_probing_rules.empty()) {
+        for (int i = 0; i < system.num_input_ports(); ++i) {
+          auto& input_port = system.get_input_port(i);
+          for (const auto& rule : blueprint_.input_port_probing_rules) {
+            if (rule.matches(input_port)) {
+              probes_.push_back(rule.builder->Build(input_port));
+            }
+          }
+        }
+      }
+    }
+
+    // Iterate over each output port in the system currently being visited.
+    // For each port, iterate over the OutputPort probing rules stored in the blueprint and see if
+    // any match.
+    // For those that match, call the related port probe builder to build a probe, and store that
+    // probe in the output port probes list.
+    void BuildOutputPortProbes(const drake::systems::System<T>& system) {
+      for (int i = 0; i < system.num_output_ports(); ++i) {
+        auto& output_port = system.get_output_port(i);
+        for (auto& rule : blueprint_.output_port_probing_rules) {
+          if (rule.matches(output_port)) {
+            probes_.push_back(rule.builder->Build(output_port));
+          }
+        }
+      }
+    }
+
+    // A reference to the blueprint.
+    const Blueprint& blueprint_;
+
+    // Port probes created during system visitation.
+    std::vector<std::unique_ptr<probes::ProbeInterface<T>>> probes_{};
+  };
+
+  // The blueprint that stores the rules for matching input and output pors when the
+  // SimulatorMonitor instance is constructed.
+  Blueprint blueprint_{};
+};
+
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/utilities/port_traits.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/utilities/port_traits.h
@@ -1,0 +1,40 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <drake/systems/framework/input_port.h>
+#include <drake/systems/framework/output_port.h>
+
+namespace drake_ros_introspection {
+namespace utilities {
+template <typename PortT>
+struct port_traits;
+
+// Provides the type of an input port as an accessible member, ScalarT.
+// For example, if the port is InputPort<double>, ScalarT will be double.
+template <typename T>
+struct port_traits<drake::systems::InputPort<T>> {
+  using ScalarT = T;
+};
+
+// Provides the type of an output port as an accessible member, ScalarT.
+// For example, if the port is OutputPort<double>, ScalarT will be double.
+template <typename T>
+struct port_traits<drake::systems::OutputPort<T>> {
+  using ScalarT = T;
+};
+
+}  // namespace utilities
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/include/drake_ros_introspection/utilities/type_conversion.h
+++ b/drake_ros_introspection/include/drake_ros_introspection/utilities/type_conversion.h
@@ -1,0 +1,52 @@
+// Copyright 2022 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <memory>
+#include <utility>
+
+#include <drake/common/value.h>
+
+namespace drake_ros_introspection {
+namespace utilities {
+
+// Base struct for conversions that have no implementation provided.
+template <typename ValueT, auto ValueTConvention, typename MessageT>
+struct convert;
+
+// Base struct for conventional conversions that have no implementation provided.
+template <typename ValueT, typename MessageT>
+struct conventional_convert;
+
+// Type conversion conventions. Used to choose a conversion method when multiple are available.
+enum class BuiltinTypeConventions { Default };
+
+// The default conversion, which just tries to simply convert a drake::AbstractValue to the ROS
+// type.
+template <typename ValueT, typename MessageT>
+struct convert<ValueT, BuiltinTypeConventions::Default, MessageT>
+    : public conventional_convert<ValueT, MessageT> {};
+
+// Attempt to convert a drake::AbstractValue into the ROS type.
+template <typename MessageT>
+struct conventional_convert<drake::AbstractValue, MessageT> {
+  static std::unique_ptr<MessageT> to_message(
+      const drake::AbstractValue& value) {
+    return std::make_unique<MessageT>(value.get_value<MessageT>());
+  }
+};
+
+}  // namespace utilities
+}  // namespace drake_ros_introspection

--- a/drake_ros_introspection/package.xml
+++ b/drake_ros_introspection/package.xml
@@ -6,6 +6,7 @@
   <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
   <maintainer email="ian.mcmahon@tri.global">Ian McMahon</maintainer>
   <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
+  <maintainer email="geoff@openrobotics.org">Shane Loretz</maintainer>
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
@@ -14,8 +15,6 @@
   <depend>drake_ros_core</depend>
   <depend>drake_ros_viz</depend>
   <depend>rclcpp</depend>
-
-  <exec_depend>std_msgs</exec_depend>
 
   <test_depend>ament_cmake_clang_format</test_depend>
   <test_depend>ament_cmake_cpplint</test_depend>

--- a/drake_ros_introspection/package.xml
+++ b/drake_ros_introspection/package.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>drake_ros_introspection</name>
+  <version>0.1.0</version>
+  <description>Drake systems introspection via ROS 2.</description>
+  <author email="michel@ekumenlabs.com">Michel Hidalgo</author>
+  <maintainer email="ian.mcmahon@tri.global">Ian McMahon</maintainer>
+  <maintainer email="sloretz@openrobotics.org">Shane Loretz</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
+
+  <depend>drake</depend>
+  <depend>drake_ros_core</depend>
+  <depend>drake_ros_viz</depend>
+  <depend>rclcpp</depend>
+
+  <exec_depend>std_msgs</exec_depend>
+
+  <test_depend>ament_cmake_clang_format</test_depend>
+  <test_depend>ament_cmake_cpplint</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/drake_ros_introspection/src/introspection_demo_iiwa.cc
+++ b/drake_ros_introspection/src/introspection_demo_iiwa.cc
@@ -1,0 +1,168 @@
+// Copyright 2021https://www.youtube.com/watch?v=SUQnduNzsw8 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <drake/common/eigen_types.h>
+#include <drake/systems/analysis/simulator.h>
+#include <drake/systems/framework/diagram_builder.h>
+#include <drake/systems/primitives/adder.h>
+#include <drake/systems/primitives/constant_vector_source.h>
+#include <drake/systems/primitives/sine.h>
+
+#include <drake/examples/manipulation_station/manipulation_station.h>
+
+#include <drake_ros_core/drake_ros.hpp>
+#include <drake_ros_core/ros_interface_system.hpp>
+#include <drake_ros_viz/rviz_visualizer.hpp>
+
+#include <drake_ros_introspection/predicates.h>
+#include <drake_ros_introspection/simulator_monitor.h>
+#include <drake_ros_introspection/simulator_monitor_builder.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float64.hpp>
+
+#include <cmath>
+#include <memory>
+#include <utility>
+
+using drake_ros_core::DrakeRos;
+using drake_ros_core::RosInterfaceSystem;
+using drake_ros_viz::RvizVisualizer;
+
+using drake::systems::Adder;
+using drake::systems::ConstantVectorSource;
+using drake::systems::Sine;
+using drake::systems::Simulator;
+using drake::examples::manipulation_station::ManipulationStation;
+
+namespace drake_ros_introspection {
+namespace utilities {
+
+template <typename T>
+struct conventional_convert<drake::systems::BasicVector<T>,
+                            std_msgs::msg::Float64> {
+  static std::unique_ptr<std_msgs::msg::Float64> to_message(
+      const drake::systems::BasicVector<T>& value) {
+    auto message = std::make_unique<std_msgs::msg::Float64>();
+    message->data = value[0];
+    return message;
+  }
+};
+
+}  // namespace utilities
+}  // namespace drake_ros_introspection
+
+
+int main(int argc, char* argv[])
+{
+  rclcpp::init(argc, argv);
+  auto node = std::make_shared<rclcpp::Node>("introspection_demo_iiwa");
+
+  drake::systems::DiagramBuilder<double> builder;
+
+  auto ros_interface_system =
+    builder.AddSystem<RosInterfaceSystem>(std::make_unique<DrakeRos>());
+
+  auto manipulation_station = builder.AddSystem<ManipulationStation>();
+  manipulation_station->SetupClutterClearingStation();
+  manipulation_station->Finalize();
+
+  // Make the base joint swing sinusoidally.
+  auto constant_term = builder.AddSystem<ConstantVectorSource>(
+    drake::VectorX<double>::Zero(manipulation_station->num_iiwa_joints()));
+
+  drake::VectorX<double> amplitudes =
+    drake::VectorX<double>::Zero(manipulation_station->num_iiwa_joints());
+  amplitudes[0] = M_PI / 4.;  // == 45 degrees
+  const drake::VectorX<double> frequencies =
+    drake::VectorX<double>::Constant(manipulation_station->num_iiwa_joints(), 1.);  // Hz
+  const drake::VectorX<double> phases =
+    drake::VectorX<double>::Zero(manipulation_station->num_iiwa_joints());
+  auto variable_term = builder.AddSystem<Sine>(amplitudes, frequencies, phases);
+
+  auto joint_trajectory_generator =
+    builder.AddSystem<Adder>(2, manipulation_station->num_iiwa_joints());
+
+  builder.Connect(
+    constant_term->get_output_port(),
+    joint_trajectory_generator->get_input_port(0));
+  builder.Connect(
+    variable_term->get_output_port(0),
+    joint_trajectory_generator->get_input_port(1));
+  builder.Connect(
+    joint_trajectory_generator->get_output_port(),
+    manipulation_station->GetInputPort("iiwa_position"));
+
+  auto rviz_visualizer = builder.AddSystem<RvizVisualizer>(
+    ros_interface_system->get_ros_interface());
+
+  rviz_visualizer->RegisterMultibodyPlant(
+    &manipulation_station->get_multibody_plant());
+
+  builder.Connect(
+    manipulation_station->GetOutputPort("query_object"),
+    rviz_visualizer->get_graph_query_port());
+
+  auto diagram = builder.Build();
+  auto context = diagram->CreateDefaultContext();
+
+  auto simulator = std::make_unique<Simulator<double>>(*diagram, std::move(context));
+  simulator->set_target_realtime_rate(1.0);
+
+  using drake_ros_introspection::SimulatorMonitor;
+  using drake_ros_introspection::SimulatorMonitorBuilder;
+  using drake_ros_introspection::predicates::DeclaredBy;
+  using drake_ros_introspection::predicates::Each;
+  using drake_ros_introspection::predicates::Named;
+  SimulatorMonitorBuilder<double> simulator_monitor_builder;
+  simulator_monitor_builder
+      .For(Each<drake::systems::OutputPort>(
+        DeclaredBy<ManipulationStation>(),
+        Named("iiwa_position_measured")))
+      .Expect<drake::systems::BasicVector>()
+      .Publish<std_msgs::msg::Float64>();
+  simulator_monitor_builder
+      .For(Each<drake::systems::OutputPort>(DeclaredBy<ManipulationStation>()))
+      .Expect<drake::systems::BasicVector>()
+      .Publish<std_msgs::msg::Float64>();
+
+  SimulatorMonitor<double> simulator_monitor =
+      simulator_monitor_builder.Build(*diagram);
+  simulator_monitor.Configure(node);
+
+  simulator->Initialize();
+
+  auto & simulator_context = simulator->get_mutable_context();
+
+  auto & manipulation_station_context =
+    diagram->GetMutableSubsystemContext(*manipulation_station, &simulator_context);
+
+  auto & constant_term_context =
+    diagram->GetMutableSubsystemContext(*constant_term, &simulator_context);
+
+  // Fix gripper joints' position.
+  manipulation_station->GetInputPort("wsg_position")
+  .FixValue(&manipulation_station_context, 0.);
+
+  // Use default positions for every joint but the base joint.
+  drake::systems::BasicVector<double> & constants =
+    constant_term->get_mutable_source_value(&constant_term_context);
+  constants.set_value(
+    manipulation_station->GetIiwaPosition(manipulation_station_context));
+  constants.get_mutable_value()[0] = -M_PI / 4.;
+
+  while (true) {
+    simulator->AdvanceTo(simulator_context.get_time() + 0.1);
+  }
+  return 0;
+}

--- a/drake_ros_introspection/src/introspection_demo_iiwa.cc
+++ b/drake_ros_introspection/src/introspection_demo_iiwa.cc
@@ -131,14 +131,11 @@ int main(int argc, char* argv[])
         Named("iiwa_position_measured")))
       .Expect<drake::systems::BasicVector>()
       .Publish<std_msgs::msg::Float64>();
-  simulator_monitor_builder
-      .For(Each<drake::systems::OutputPort>(DeclaredBy<ManipulationStation>()))
-      .Expect<drake::systems::BasicVector>()
-      .Publish<std_msgs::msg::Float64>();
 
   SimulatorMonitor<double> simulator_monitor =
       simulator_monitor_builder.Build(*diagram);
   simulator_monitor.Configure(node);
+  simulator->set_monitor(simulator_monitor);
 
   simulator->Initialize();
 

--- a/drake_ros_introspection/src/introspection_demo_sine.cc
+++ b/drake_ros_introspection/src/introspection_demo_sine.cc
@@ -1,0 +1,98 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <chrono>
+#include <memory>
+#include <utility>
+
+#include <drake/systems/analysis/simulator.h>
+#include <drake/systems/framework/diagram.h>
+#include <drake/systems/framework/diagram_builder.h>
+#include <drake/systems/primitives/sine.h>
+#include <drake_ros_introspection/predicates.h>
+#include <drake_ros_introspection/simulator_monitor.h>
+#include <drake_ros_introspection/simulator_monitor_builder.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/float64.hpp>
+
+namespace drake_ros_introspection {
+namespace utilities {
+
+template <typename T>
+struct conventional_convert<drake::systems::BasicVector<T>,
+                            std_msgs::msg::Float64> {
+  static std::unique_ptr<std_msgs::msg::Float64> to_message(
+      const drake::systems::BasicVector<T>& value) {
+    auto message = std::make_unique<std_msgs::msg::Float64>();
+    message->data = value[0];
+    return message;
+  }
+};
+
+}  // namespace utilities
+}  // namespace drake_ros_introspection
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+
+  auto node = std::make_shared<rclcpp::Node>("introspection_demo_sine");
+
+  drake::systems::DiagramBuilder<double> builder;
+
+  constexpr double kAmplitude = 1.;
+  constexpr double kFrequency = 1.;
+  constexpr double kPhase = 1.;
+  constexpr int kSize = 1;
+  auto source_system = builder.AddSystem<drake::systems::Sine>(
+      kAmplitude, kFrequency, kPhase, kSize);
+  source_system->set_name("sine");
+
+  std::unique_ptr<drake::systems::Diagram<double>> diagram = builder.Build();
+  diagram->set_name("introspection_demo");
+
+  auto simulator = std::make_unique<drake::systems::Simulator<double>>(
+      *diagram, diagram->CreateDefaultContext());
+  simulator->set_target_realtime_rate(1.0);
+
+  using drake_ros_introspection::SimulatorMonitor;
+  using drake_ros_introspection::SimulatorMonitorBuilder;
+  using drake_ros_introspection::predicates::DeclaredBy;
+  using drake_ros_introspection::predicates::Each;
+  SimulatorMonitorBuilder<double> simulator_monitor_builder;
+  simulator_monitor_builder
+      .For(Each<drake::systems::OutputPort>(DeclaredBy<drake::systems::Sine>()))
+      .Expect<drake::systems::BasicVector>()
+      .Publish<std_msgs::msg::Float64>();
+
+  SimulatorMonitor<double> simulator_monitor =
+      simulator_monitor_builder.Build(*diagram);
+  simulator_monitor.Configure(node);
+  simulator->set_monitor(simulator_monitor);
+
+  simulator->Initialize();
+
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
+
+  const drake::systems::Context<double>& simulator_context =
+      simulator->get_context();
+  while (rclcpp::ok()) {
+    simulator->AdvanceTo(simulator_context.get_time() + 0.1);
+    executor.spin_once(std::chrono::nanoseconds::zero());
+  }
+  executor.remove_node(node);
+
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
This PR adds the `drake_ros_introspection` package, which exposes selected Drake system ports as ROS 2 topics.

Most of this work was done by @hidmic in #32. I cleaned up the API a little and added an extra example using the `ManipulationStation` example system.

The package currently has two shortcomings:
1. It does not integrate with `drake_ros_core`, which it should.
2. It only handles data going from Drake to ROS. It is not yet possible to take data from a ROS topic and push it into a Drake system.

Nevertheless I'd like to get this merged then address these two issues as separate PRs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/93)
<!-- Reviewable:end -->
