### PR TITLE
Add option to set RMW_LOCALHOST_ONLY by default

### DIFF
--- a/bazel_ros2_rules/ros2/defs.bzl
+++ b/bazel_ros2_rules/ros2/defs.bzl
@@ -116,6 +116,8 @@ def base_ros2_repository(repo_ctx, workspaces):
         cmd.extend(["-s", path + ":" + path_in_sandbox])
     cmd.extend(["-d", "distro_metadata.json", repo_ctx.name])
     cmd.extend(["-o", "distro.bzl"])
+    if repo_ctx.attr.default_localhost_only:
+        cmd.extend(["--default-localhost-only"])
     result = execute_or_fail(repo_ctx, cmd, quiet=True, environment=env)
     if result.stderr:
         print(result.stderr)
@@ -163,6 +165,11 @@ def base_ros2_repository_attrs():
             doc = "Number of CMake jobs to use during package " +
             "configuration and scrapping. Defaults to using all cores.",
             default=0,
+        ),
+        "default_localhost_only": attr.bool(
+            doc = "Whether ROS communication should be restricted to " +
+            "localhost by default. Defaults to False",
+            default=False,
         ),
         # NOTE: all these labels are listed as private attributes to force prefetching, or else
         # repository rules will be restarted on first hit.

--- a/bazel_ros2_rules/ros2/generate_distro_file.py
+++ b/bazel_ros2_rules/ros2/generate_distro_file.py
@@ -45,6 +45,11 @@ def parse_arguments():
         help='Path to distro metadata file, in JSON format'
     )
     parser.add_argument(
+        '--default-localhost-only',
+        action='store_true', required=False,
+        help='Restrict ROS 2 to localhost communication by default'
+    )
+    parser.add_argument(
         'repository_name', help='Bazel repository name'
     )
     args = parser.parse_args()
@@ -66,7 +71,9 @@ ROSIDL_TYPESUPPORT_GROUPS = [
 ]
 
 
-def generate_distro_file_content(repo_name, distro, sandbox):
+def generate_distro_file_content(
+        repo_name, distro, sandbox, default_localhost_only
+        ):
     packages = distro['packages']
     ament_prefix_paths = distro['paths']['ament_prefix']
     library_load_paths = distro['paths']['library_load']
@@ -84,6 +91,7 @@ def generate_distro_file_content(repo_name, distro, sandbox):
                     for group in metadata['groups']
                 )],
             'REPOSITORY_ROOT': '@{}//'.format(repo_name),
+            'DEFAULT_LOCALHOST_ONLY': '1' if default_localhost_only else '0',
         })
     ) + '\n'
 
@@ -92,7 +100,8 @@ def main():
     args = parse_arguments()
 
     args.output.write(generate_distro_file_content(
-        args.repository_name, args.distro, args.sandbox))
+        args.repository_name, args.distro, args.sandbox,
+        args.default_localhost_only))
 
 
 if __name__ == '__main__':

--- a/bazel_ros2_rules/ros2/resources/templates/distro.bzl.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/distro.bzl.tpl
@@ -6,4 +6,5 @@ REPOSITORY_ROOT = @REPOSITORY_ROOT@
 RUNTIME_ENVIRONMENT = {
   "AMENT_PREFIX_PATH": ["path-prepend"] + @AMENT_PREFIX_PATHS@,
   "${LOAD_PATH}": ["path-prepend"] + @LOAD_PATHS@,
+  "RMW_LOCALHOST_ONLY": ["set-if-not-set", @DEFAULT_LOCALHOST_ONLY@],
 }

--- a/bazel_ros2_rules/ros2/tools/dload.bzl
+++ b/bazel_ros2_rules/ros2/tools/dload.bzl
@@ -72,8 +72,9 @@ def do_dload_shim(ctx, template, to_list):
         env_changes: runtime environment changes to be applied, as a mapping from
           environment variable names to actions to be performed on them.
           Actions are (action_type, action_args) tuples. Supported action types
-          are: 'path-prepend', 'path-replace', and 'replace'. Paths are resolved
-          relative to the runfiles directory of the downstream executable.
+          are: 'path-prepend', 'path-replace', 'set-if-not-set', and 'replace'.
+          Paths are resolved relative to the runfiles directory of the
+          downstream executable.
           Also, see MAGIC_VARIABLES for platform-independent runtime environment
           specification.
 
@@ -130,7 +131,7 @@ def _parse_runtime_environment_action(ctx, action):
             _resolve_runfile_path(ctx, path[:-1]) + "!" if path.endswith("!")
             else _resolve_runfile_path(ctx, path) for path in action_args
         ])
-    elif action_type in ("path-replace", "replace"):
+    elif action_type in ("path-replace", "set-if-not-set", "replace"):
         if len(action_args) != 1:
             tpl = "'{}' action requires exactly one argument"
             fail(msg = tpl.format(action_type))

--- a/bazel_ros2_rules/ros2/tools/dload_cc.bzl
+++ b/bazel_ros2_rules/ros2/tools/dload_cc.bzl
@@ -42,6 +42,12 @@ int main(int argc, const char * argv[]) {{
     if (actions[i][0] == "replace") {{
       assert(actions[i].size() == 2);
       value_stream << actions[i][1];
+    }} else if (actions[i][0] == "set-if-not-set") {{
+      assert(actions[i].size() == 2);
+      if (NULL != getenv(names[i].c_str())) {{
+        continue;
+      }}
+      value_stream << actions[i][1];
     }} else if (actions[i][0] == "path-replace") {{
       assert(actions[i].size() == 2);
       value_stream << runfiles->Rlocation(actions[i][1]);

--- a/bazel_ros2_rules/ros2/tools/dload_py.bzl
+++ b/bazel_ros2_rules/ros2/tools/dload_py.bzl
@@ -34,6 +34,11 @@ def main(argv):
         if action_type == 'replace':
             assert len(action_args) == 1
             value = action_args[0]
+        elif action_type == 'set-if-not-set':
+            assert len(action_args) == 1
+            if name in os.environ:
+                continue
+            value = action_args[0]
         elif action_type == 'path-replace':
             assert len(action_args) == 1
             value = rlocation(action_args[0])


### PR DESCRIPTION
This adds an option to `bazel_ros2_rules` that allows configuring whether `RMW_LOCALHOST_ONLY` is set to 0 or 1 by default.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/94)
<!-- Reviewable:end -->
