### PR TITLE
Error when requested package doesn't exist in ROS 2 workspace

### DIFF
--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/__init__.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/__init__.py
@@ -39,6 +39,10 @@ def index_all_packages():
 def build_dependency_graph(packages, include=None, exclude=None):
     package_set = set(packages)
     if include:
+        include = set(include)
+        if not package_set.issuperset(include):
+            unknown_packages = include.difference(package_set)
+            raise RuntimeError(f'Cannot find packages {unknown_packages}')
         package_set &= include
     if exclude:
         package_set -= exclude

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/__init__.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/__init__.py
@@ -41,8 +41,13 @@ def build_dependency_graph(packages, include=None, exclude=None):
     if include:
         include = set(include)
         if not package_set.issuperset(include):
-            unknown_packages = include.difference(package_set)
-            raise RuntimeError(f'Cannot find packages {unknown_packages}')
+            unknown_packages = tuple(include.difference(package_set))
+            msg = 'Cannont find package'
+            if len(unknown_packages) == 1:
+                msg +=  ' ' + repr(unknown_packages[0])
+            else:
+                msg += 's ' + repr(unknown_packages)
+            raise RuntimeError(msg)
         package_set &= include
     if exclude:
         package_set -= exclude

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -28,7 +28,7 @@ ROS2_PACKAGES = [
     "ros2cli_common_extensions",
     # RMW implementations
     "rmw_cyclonedds_cpp",
-    "rmw_fastrtps_cpp",
+    # "rmw_fastrtps_cpp",
 ]
 
 ros2_archive(

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -27,6 +27,7 @@ ROS2_PACKAGES = [
     "ros2cli",
     "ros2cli_common_extensions",
     # RMW implementations
+    # Uncomment one and only one to change implementations
     "rmw_cyclonedds_cpp",
     # "rmw_fastrtps_cpp",
 ]


### PR DESCRIPTION
Fixes #100

Here's what it looks like with a non-existent package

```
bazel build //...
INFO: Repository ros2 instantiated at:
  /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/WORKSPACE:34:13: in <toplevel>
Repository rule ros2_archive defined at:
  /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/defs.bzl:307:31: in <toplevel>
INFO: Repository 'ros2' used the following cache hits instead of downloading the corresponding file.
 * Hash '87ba25ac7f97a220cfaeb7ac577c3bb7e3c36040f41e16309d55b8847a895682' for http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci.tar.bz2
If the definition of 'ros2' was updated, verify that the hashes were also updated.
ERROR: An error occurred during the fetch of repository 'ros2':
   Traceback (most recent call last):
	File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/defs.bzl", line 300, column 25, in _ros2_archive_impl
		base_ros2_repository(repo_ctx, workspaces_in_sandbox)
	File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/defs.bzl", line 107, column 29, in base_ros2_repository
		result = execute_or_fail(repo_ctx, cmd, quiet=True, environment=env)
	File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/tools/execute.bzl", line 16, column 13, in execute_or_fail
		fail("Failed to setup @{} repository: {}".format(
Error in fail: Failed to setup @ros2 repository: './run.bash /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py -i action_msgs -i builtin_interfaces -i rosidl_default_generators -i rclcpp_action -i rclcpp -i rclpy -i ros2cli -i ros2cli_common_extensions -i rmw_cyclonedds_cpp -i does_not_exist -o distro_metadata.json' exited with 1
--- captured stderr ---
Traceback (most recent call last):
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py", line 54, in <module>
    main()
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py", line 46, in main
    distro = scrape_distribution(
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/resources/ros2bzl/scraping/__init__.py", line 85, in scrape_distribution
    packages, dependency_graph = build_dependency_graph(
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/resources/ros2bzl/scraping/__init__.py", line 45, in build_dependency_graph
    raise RuntimeError(f'Cannot find packages {unknown_packages}')
RuntimeError: Cannot find packages {'does_not_exist'}
ERROR: /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/WORKSPACE:34:13: fetching ros2_archive rule //external:ros2: Traceback (most recent call last):
	File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/defs.bzl", line 300, column 25, in _ros2_archive_impl
		base_ros2_repository(repo_ctx, workspaces_in_sandbox)
	File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/defs.bzl", line 107, column 29, in base_ros2_repository
		result = execute_or_fail(repo_ctx, cmd, quiet=True, environment=env)
	File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/tools/execute.bzl", line 16, column 13, in execute_or_fail
		fail("Failed to setup @{} repository: {}".format(
Error in fail: Failed to setup @ros2 repository: './run.bash /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py -i action_msgs -i builtin_interfaces -i rosidl_default_generators -i rclcpp_action -i rclcpp -i rclpy -i ros2cli -i ros2cli_common_extensions -i rmw_cyclonedds_cpp -i does_not_exist -o distro_metadata.json' exited with 1
--- captured stderr ---
Traceback (most recent call last):
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py", line 54, in <module>
    main()
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py", line 46, in main
    distro = scrape_distribution(
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/resources/ros2bzl/scraping/__init__.py", line 85, in scrape_distribution
    packages, dependency_graph = build_dependency_graph(
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/resources/ros2bzl/scraping/__init__.py", line 45, in build_dependency_graph
    raise RuntimeError(f'Cannot find packages {unknown_packages}')
RuntimeError: Cannot find packages {'does_not_exist'}
ERROR: no such package '@ros2//': Failed to setup @ros2 repository: './run.bash /home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py -i action_msgs -i builtin_interfaces -i rosidl_default_generators -i rclcpp_action -i rclcpp -i rclpy -i ros2cli -i ros2cli_common_extensions -i rmw_cyclonedds_cpp -i does_not_exist -o distro_metadata.json' exited with 1
--- captured stderr ---
Traceback (most recent call last):
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py", line 54, in <module>
    main()
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/bazel_ros2_rules/ros2/scrape_distribution.py", line 46, in main
    distro = scrape_distribution(
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/resources/ros2bzl/scraping/__init__.py", line 85, in scrape_distribution
    packages, dependency_graph = build_dependency_graph(
  File "/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/resources/ros2bzl/scraping/__init__.py", line 45, in build_dependency_graph
    raise RuntimeError(f'Cannot find packages {unknown_packages}')
RuntimeError: Cannot find packages {'does_not_exist'}
INFO: Elapsed time: 3.886s
INFO: 0 processes.
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/109)
<!-- Reviewable:end -->
