### PR TITLE
Rename not-shimmed executables

### DIFF
--- a/bazel_ros2_rules/ros2/ros_cc.bzl
+++ b/bazel_ros2_rules/ros2/ros_cc.bzl
@@ -39,7 +39,7 @@ def ros_cc_binary(
         native.cc_binary(name = name, **kwargs)
         return
 
-    binary_name = "_" + name + "_shimmed"
+    binary_name = "_" + name + "_noshim"
     binary_kwargs = kwargs
     binary_env_changes = dict(RUNTIME_ENVIRONMENT)
 
@@ -93,7 +93,7 @@ def ros_cc_test(
     Additional keyword arguments are forwarded to the `cc_test_rule` and to the
     `cc_binary_rule` (minus the test specific ones).
     """
-    binary_name = "_" + name + "_shimmed"
+    binary_name = "_" + name + "_noshim"
     binary_kwargs = remove_test_specific_kwargs(kwargs)
     binary_kwargs.update(testonly = True)
     binary_env_changes = dict(RUNTIME_ENVIRONMENT)

--- a/bazel_ros2_rules/ros2/ros_cc.bzl
+++ b/bazel_ros2_rules/ros2/ros_cc.bzl
@@ -39,34 +39,34 @@ def ros_cc_binary(
         native.cc_binary(name = name, **kwargs)
         return
 
-    binary_name = "_" + name + "_noshim"
-    binary_kwargs = kwargs
-    binary_env_changes = dict(RUNTIME_ENVIRONMENT)
+    noshim_name = "_" + name + "_noshim"
+    noshim_kwargs = kwargs
+    shim_env_changes = dict(RUNTIME_ENVIRONMENT)
 
     if rmw_implementation:
-        binary_kwargs, binary_env_changes = \
+        noshim_kwargs, shim_env_changes = \
             incorporate_rmw_implementation(
-                binary_kwargs, binary_env_changes,
+                noshim_kwargs, shim_env_changes,
                 rmw_implementation = rmw_implementation
             )
 
     cc_binary_rule(
-        name = binary_name,
-        **binary_kwargs
+        name = noshim_name,
+        **noshim_kwargs
     )
 
     shim_name = "_" + name + "_shim.cc"
     shim_kwargs = filter_to_only_common_kwargs(kwargs)
     dload_cc_shim(
         name = shim_name,
-        target = ":" + binary_name,
-        env_changes = binary_env_changes,
+        target = ":" + noshim_name,
+        env_changes = shim_env_changes,
         **shim_kwargs
     )
 
     kwargs.update(
         srcs = [shim_name],
-        data = [":" + binary_name],
+        data = [":" + noshim_name],
         deps = ["@bazel_tools//tools/cpp/runfiles"],
         tags = ["nolint"] + kwargs.get("tags", [])
     )
@@ -93,20 +93,20 @@ def ros_cc_test(
     Additional keyword arguments are forwarded to the `cc_test_rule` and to the
     `cc_binary_rule` (minus the test specific ones).
     """
-    binary_name = "_" + name + "_noshim"
-    binary_kwargs = remove_test_specific_kwargs(kwargs)
-    binary_kwargs.update(testonly = True)
-    binary_env_changes = dict(RUNTIME_ENVIRONMENT)
+    noshim_name = "_" + name + "_noshim"
+    noshim_kwargs = remove_test_specific_kwargs(kwargs)
+    noshim_kwargs.update(testonly = True)
+    shim_env_changes = dict(RUNTIME_ENVIRONMENT)
     if rmw_implementation:
-        binary_kwargs, test_env_changes = \
+        noshim_kwargs, test_env_changes = \
             incorporate_rmw_implementation(
-                binary_kwargs, binary_env_changes,
+                noshim_kwargs, shim_env_changes,
                 rmw_implementation = rmw_implementation
             )
 
     cc_binary_rule(
-        name = binary_name,
-        **binary_kwargs
+        name = noshim_name,
+        **noshim_kwargs
     )
 
     shim_name = "_" + name + "_shim.cc"
@@ -114,14 +114,14 @@ def ros_cc_test(
     shim_kwargs.update(testonly = True)
     dload_cc_shim(
         name = shim_name,
-        target = ":" + binary_name,
-        env_changes = binary_env_changes,
+        target = ":" + noshim_name,
+        env_changes = shim_env_changes,
         **shim_kwargs
     )
 
     kwargs.update(
         srcs = [shim_name],
-        data = [":" + binary_name],
+        data = [":" + noshim_name],
         deps = ["@bazel_tools//tools/cpp/runfiles"],
         tags = ["nolint"] + kwargs.get("tags", [])
     )

--- a/bazel_ros2_rules/ros2/ros_py.bzl
+++ b/bazel_ros2_rules/ros2/ros_py.bzl
@@ -83,40 +83,40 @@ def ros_py_binary(
     Additional keyword arguments are forwarded to the `py_binary_rule`.
     """
 
-    binary_name = "_" + name + "_noshim"
-    binary_kwargs = dict(kwargs)
-    if "main" not in binary_kwargs:
-        binary_kwargs["main"] = name + ".py"
-    binary_env_changes = dict(RUNTIME_ENVIRONMENT)
+    noshim_name = "_" + name + "_noshim"
+    noshim_kwargs = dict(kwargs)
+    if "main" not in noshim_kwargs:
+        noshim_kwargs["main"] = name + ".py"
+    shim_env_changes = dict(RUNTIME_ENVIRONMENT)
 
     if rmw_implementation:
-        binary_kwargs, binary_env_changes = \
+        noshim_kwargs, shim_env_changes = \
             incorporate_rmw_implementation(
-                binary_kwargs, binary_env_changes,
+                noshim_kwargs, shim_env_changes,
                 rmw_implementation = rmw_implementation
             )
 
     py_binary_rule(
-        name = binary_name,
-        **binary_kwargs
+        name = noshim_name,
+        **noshim_kwargs
     )
 
     shim_name = "_" + name + "_shim.py"
     shim_kwargs = filter_to_only_common_kwargs(kwargs)
     dload_py_shim(
         name = shim_name,
-        target = ":" + binary_name,
-        env_changes = binary_env_changes,
+        target = ":" + noshim_name,
+        env_changes = shim_env_changes,
         **shim_kwargs
     )
 
     kwargs.update(
         srcs = [shim_name],
         main = shim_name,
-        data = [":" + binary_name],
+        data = [":" + noshim_name],
         deps = [
             "@bazel_tools//tools/python/runfiles",
-            ":" + binary_name,  # Support py_binary being used a dependency
+            ":" + noshim_name,  # Support py_binary being used a dependency
         ],
         tags = ["nolint"] + kwargs.get("tags", [])
     )
@@ -143,20 +143,20 @@ def ros_py_test(
     Additional keyword arguments are forwarded to the `py_test_rule` and to the
     `py_binary_rule` (minus the test specific ones).
     """
-    binary_name = "_" + name + "_noshim"
-    binary_kwargs = remove_test_specific_kwargs(kwargs)
-    binary_kwargs.update(testonly = True)
-    binary_env_changes = dict(RUNTIME_ENVIRONMENT)
+    noshim_name = "_" + name + "_noshim"
+    noshim_kwargs = remove_test_specific_kwargs(kwargs)
+    noshim_kwargs.update(testonly = True)
+    shim_env_changes = dict(RUNTIME_ENVIRONMENT)
     if rmw_implementation:
-        binary_kwargs, binary_env_changes = \
+        noshim_kwargs, shim_env_changes = \
             incorporate_rmw_implementation(
-                binary_kwargs, binary_env_changes,
+                noshim_kwargs, shim_env_changes,
                 rmw_implementation = rmw_implementation,
             )
 
     py_binary_rule(
-        name = binary_name,
-        **binary_kwargs
+        name = noshim_name,
+        **noshim_kwargs
     )
 
     shim_name = "_" + name + "_shim.py"
@@ -164,15 +164,15 @@ def ros_py_test(
     shim_kwargs.update(testonly = True)
     dload_py_shim(
         name = shim_name,
-        target = ":" + binary_name,
-        env_changes = binary_env_changes,
+        target = ":" + noshim_name,
+        env_changes = shim_env_changes,
         **shim_kwargs
     )
 
     kwargs.update(
         srcs = [shim_name],
         main = shim_name,
-        data = [":" + binary_name],
+        data = [":" + noshim_name],
         deps = ["@bazel_tools//tools/python/runfiles"],
         tags = ["nolint"] + kwargs.get("tags", [])
     )

--- a/bazel_ros2_rules/ros2/ros_py.bzl
+++ b/bazel_ros2_rules/ros2/ros_py.bzl
@@ -83,7 +83,7 @@ def ros_py_binary(
     Additional keyword arguments are forwarded to the `py_binary_rule`.
     """
 
-    binary_name = "_" + name + "_shimmed"
+    binary_name = "_" + name + "_noshim"
     binary_kwargs = dict(kwargs)
     if "main" not in binary_kwargs:
         binary_kwargs["main"] = name + ".py"
@@ -143,7 +143,7 @@ def ros_py_test(
     Additional keyword arguments are forwarded to the `py_test_rule` and to the
     `py_binary_rule` (minus the test specific ones).
     """
-    binary_name = "_" + name + "_shimmed"
+    binary_name = "_" + name + "_noshim"
     binary_kwargs = remove_test_specific_kwargs(kwargs)
     binary_kwargs.update(testonly = True)
     binary_env_changes = dict(RUNTIME_ENVIRONMENT)


### PR DESCRIPTION
This renames the not-shimmed binaries from `_*_shimmed` to `_*_noshim`. This is something @EricCousineau-TRI suggested when he was helping me with questions about this code last week.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/112)
<!-- Reviewable:end -->
