### PR TITLE
Add reproduction of RobotLocomotion/drake-ros#113

### DIFF
--- a/ros2_example_bazel_installed/BUILD.bazel
+++ b/ros2_example_bazel_installed/BUILD.bazel
@@ -32,3 +32,18 @@ ros_py_test(
     deps = ["@bazel_tools//tools/python/runfiles"],
     data = ["test/runfiles_test_data.txt"],
 )
+
+cc_library(
+  name = "lib_with_ros",
+  srcs = ["test/lib_with_ros.cc"],
+  hdrs = ["test/lib_with_ros.h"],
+  deps = ["@ros2//:rclcpp_cc"]
+)
+
+cc_binary(
+  name = "bin_unaware_of_ros",
+  srcs = ["test/bin_unaware_of_ros.cc"],
+  deps = [":lib_with_ros"]
+)
+
+# bazel run //:bin_unaware_of_ros

--- a/ros2_example_bazel_installed/test/bin_unaware_of_ros.cc
+++ b/ros2_example_bazel_installed/test/bin_unaware_of_ros.cc
@@ -1,0 +1,6 @@
+#include "lib_with_ros.h"
+
+int main(int argc, char* argv[]) {
+  some_function();
+  return 0;
+}

--- a/ros2_example_bazel_installed/test/lib_with_ros.cc
+++ b/ros2_example_bazel_installed/test/lib_with_ros.cc
@@ -1,0 +1,11 @@
+#include "lib_with_ros.h"
+
+#include <rclcpp/rclcpp.hpp>
+
+void some_function()
+{
+  rclcpp::init(0, nullptr);
+  auto node = std::make_shared<rclcpp::Node>("lib_node");
+  rclcpp::spin(node);
+  rclcpp::shutdown();
+}

--- a/ros2_example_bazel_installed/test/lib_with_ros.h
+++ b/ros2_example_bazel_installed/test/lib_with_ros.h
@@ -1,0 +1,1 @@
+void some_function();


### PR DESCRIPTION
RobotLocomotion/drake-ros#113

`bazel run //:bin_unaware_of_ros`

It looks like binaries can use ROS 2 without the shim.


```console
$ ldd bazel-bin/bin_unaware_of_ros
	linux-vdso.so.1 (0x00007ffd42de2000)
	librclcpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crclcpp_Ucc___Uarchive_Slib/librclcpp.so (0x00007f6bd1ccc000)
	liblibstatistics_collector.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Clibstatistics_Ucollector_Ucc___Uarchive_Slib/liblibstatistics_collector.so (0x00007f6bd1cc5000)
	libstd_msgs__rosidl_typesupport_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstd_Umsgs_Ucc___Uarchive_Slib/libstd_msgs__rosidl_typesupport_cpp.so (0x00007f6bd1cbd000)
	libstd_msgs__rosidl_typesupport_introspection_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstd_Umsgs_Ucc___Uarchive_Slib/libstd_msgs__rosidl_typesupport_introspection_cpp.so (0x00007f6bd1ca6000)
	libstd_msgs__rosidl_generator_py.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstd_Umsgs_Ucc___Uarchive_Slib/libstd_msgs__rosidl_generator_py.so (0x00007f6bd1c96000)
	libstd_msgs__rosidl_generator_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstd_Umsgs_Ucc___Uarchive_Slib/libstd_msgs__rosidl_generator_c.so (0x00007f6bd1c78000)
	libstd_msgs__rosidl_typesupport_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstd_Umsgs_Ucc___Uarchive_Slib/libstd_msgs__rosidl_typesupport_c.so (0x00007f6bd1c71000)
	libstd_msgs__rosidl_typesupport_introspection_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstd_Umsgs_Ucc___Uarchive_Slib/libstd_msgs__rosidl_typesupport_introspection_c.so (0x00007f6bd1c5e000)
	librcl.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Ucc___Uarchive_Slib/librcl.so (0x00007f6bd1c1f000)
	librcl_interfaces__rosidl_typesupport_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Uinterfaces_Ucc___Uarchive_Slib/librcl_interfaces__rosidl_typesupport_cpp.so (0x00007f6bd1c17000)
	librcl_interfaces__rosidl_typesupport_introspection_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Uinterfaces_Ucc___Uarchive_Slib/librcl_interfaces__rosidl_typesupport_introspection_cpp.so (0x00007f6bd1bf4000)
	librcl_interfaces__rosidl_generator_py.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Uinterfaces_Ucc___Uarchive_Slib/librcl_interfaces__rosidl_generator_py.so (0x00007f6bd1be3000)
	librcl_interfaces__rosidl_generator_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Uinterfaces_Ucc___Uarchive_Slib/librcl_interfaces__rosidl_generator_c.so (0x00007f6bd1bca000)
	librcl_interfaces__rosidl_typesupport_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Uinterfaces_Ucc___Uarchive_Slib/librcl_interfaces__rosidl_typesupport_c.so (0x00007f6bd1bc1000)
	librcl_interfaces__rosidl_typesupport_introspection_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Uinterfaces_Ucc___Uarchive_Slib/librcl_interfaces__rosidl_typesupport_introspection_c.so (0x00007f6bd1ba8000)
	libtracetools.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Ctracetools_Ucc___Uarchive_Slib/libtracetools.so (0x00007f6bd1ba3000)
	librmw_cyclonedds_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librmw_cyclonedds_cpp.so (0x00007f6bd1b19000)
	libddsc.so.0 => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/libddsc.so.0 (0x00007f6bd19de000)
	librmw_dds_common.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librmw_dds_common.so (0x00007f6bd19c1000)
	librmw.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librmw.so (0x00007f6bd19b5000)
	librmw_dds_common__rosidl_typesupport_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librmw_dds_common__rosidl_typesupport_cpp.so (0x00007f6bd19b0000)
	librosidl_typesupport_introspection_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librosidl_typesupport_introspection_cpp.so (0x00007f6bd19ab000)
	librosidl_typesupport_introspection_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librosidl_typesupport_introspection_c.so (0x00007f6bd19a6000)
	librosidl_runtime_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librosidl_runtime_c.so (0x00007f6bd1999000)
	libiceoryx_binding_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/libiceoryx_binding_c.so (0x00007f6bd1962000)
	librmw_dds_common__rosidl_typesupport_introspection_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/librmw_dds_common__rosidl_typesupport_introspection_cpp.so (0x00007f6bd195a000)
	libiceoryx_posh.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/libiceoryx_posh.so (0x00007f6bd185b000)
	libiceoryx_hoofs.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/libiceoryx_hoofs.so (0x00007f6bd17e1000)
	libiceoryx_platform.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib/libiceoryx_platform.so (0x00007f6bd17da000)
	libament_index_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cament_Uindex_Ucpp_Ucc___Uarchive_Slib/libament_index_cpp.so (0x00007f6bd17cf000)
	librcl_logging_spdlog.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Ulogging_Uspdlog_Ucc___Uarchive_Slib/librcl_logging_spdlog.so (0x00007f6bd17c5000)
	librcl_logging_interface.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Ulogging_Uinterface_Ucc___Uarchive_Slib/librcl_logging_interface.so (0x00007f6bd17c0000)
	libstatistics_msgs__rosidl_typesupport_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstatistics_Umsgs_Ucc___Uarchive_Slib/libstatistics_msgs__rosidl_typesupport_cpp.so (0x00007f6bd17bb000)
	libstatistics_msgs__rosidl_typesupport_introspection_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstatistics_Umsgs_Ucc___Uarchive_Slib/libstatistics_msgs__rosidl_typesupport_introspection_cpp.so (0x00007f6bd17b3000)
	libstatistics_msgs__rosidl_generator_py.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstatistics_Umsgs_Ucc___Uarchive_Slib/libstatistics_msgs__rosidl_generator_py.so (0x00007f6bd17ad000)
	libstatistics_msgs__rosidl_generator_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstatistics_Umsgs_Ucc___Uarchive_Slib/libstatistics_msgs__rosidl_generator_c.so (0x00007f6bd17a6000)
	libstatistics_msgs__rosidl_typesupport_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstatistics_Umsgs_Ucc___Uarchive_Slib/libstatistics_msgs__rosidl_typesupport_c.so (0x00007f6bd17a1000)
	libstatistics_msgs__rosidl_typesupport_introspection_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cstatistics_Umsgs_Ucc___Uarchive_Slib/libstatistics_msgs__rosidl_typesupport_introspection_c.so (0x00007f6bd179b000)
	librosgraph_msgs__rosidl_typesupport_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosgraph_Umsgs_Ucc___Uarchive_Slib/librosgraph_msgs__rosidl_typesupport_cpp.so (0x00007f6bd1794000)
	librosgraph_msgs__rosidl_typesupport_introspection_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosgraph_Umsgs_Ucc___Uarchive_Slib/librosgraph_msgs__rosidl_typesupport_introspection_cpp.so (0x00007f6bd178f000)
	librosgraph_msgs__rosidl_generator_py.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosgraph_Umsgs_Ucc___Uarchive_Slib/librosgraph_msgs__rosidl_generator_py.so (0x00007f6bd178a000)
	librosgraph_msgs__rosidl_typesupport_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosgraph_Umsgs_Ucc___Uarchive_Slib/librosgraph_msgs__rosidl_typesupport_c.so (0x00007f6bd1785000)
	librosgraph_msgs__rosidl_typesupport_introspection_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosgraph_Umsgs_Ucc___Uarchive_Slib/librosgraph_msgs__rosidl_typesupport_introspection_c.so (0x00007f6bd1780000)
	librosgraph_msgs__rosidl_generator_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosgraph_Umsgs_Ucc___Uarchive_Slib/librosgraph_msgs__rosidl_generator_c.so (0x00007f6bd1779000)
	libbuiltin_interfaces__rosidl_typesupport_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cbuiltin_Uinterfaces_Ucc___Uarchive_Slib/libbuiltin_interfaces__rosidl_typesupport_cpp.so (0x00007f6bd1774000)
	libbuiltin_interfaces__rosidl_typesupport_introspection_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cbuiltin_Uinterfaces_Ucc___Uarchive_Slib/libbuiltin_interfaces__rosidl_typesupport_introspection_cpp.so (0x00007f6bd176f000)
	libbuiltin_interfaces__rosidl_generator_py.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cbuiltin_Uinterfaces_Ucc___Uarchive_Slib/libbuiltin_interfaces__rosidl_generator_py.so (0x00007f6bd176a000)
	libbuiltin_interfaces__rosidl_typesupport_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cbuiltin_Uinterfaces_Ucc___Uarchive_Slib/libbuiltin_interfaces__rosidl_typesupport_c.so (0x00007f6bd1765000)
	libbuiltin_interfaces__rosidl_typesupport_introspection_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cbuiltin_Uinterfaces_Ucc___Uarchive_Slib/libbuiltin_interfaces__rosidl_typesupport_introspection_c.so (0x00007f6bd175e000)
	libbuiltin_interfaces__rosidl_generator_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cbuiltin_Uinterfaces_Ucc___Uarchive_Slib/libbuiltin_interfaces__rosidl_generator_c.so (0x00007f6bd1759000)
	librosidl_typesupport_cpp.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosidl_Utypesupport_Ucpp_Ucc___Uarchive_Slib/librosidl_typesupport_cpp.so (0x00007f6bd1753000)
	librosidl_typesupport_c.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crosidl_Utypesupport_Uc_Ucc___Uarchive_Slib/librosidl_typesupport_c.so (0x00007f6bd174d000)
	librcpputils.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcpputils_Ucc___Uarchive_Slib/librcpputils.so (0x00007f6bd173b000)
	librcl_yaml_param_parser.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcl_Uyaml_Uparam_Uparser_Ucc___Uarchive_Slib/librcl_yaml_param_parser.so (0x00007f6bd172c000)
	libyaml.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Cyaml_Ucc___Uarchive_Slib/libyaml.so (0x00007f6bd1709000)
	librcutils.so => /home/osrf/ws/drake/src/drake-ros/ros2_example_bazel_installed/bazel-bin/_solib_k8/_U@ros2_S_S_Crcutils_Ucc___Uarchive_Slib/librcutils.so (0x00007f6bd16f0000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f6bd14dc000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f6bd138d000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f6bd1370000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f6bd117e000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f6bd115b000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f6bd1f67000)
	libpython3.8.so.1.0 => /lib/x86_64-linux-gnu/libpython3.8.so.1.0 (0x00007f6bd0c05000)
	libssl.so.1.1 => /lib/x86_64-linux-gnu/libssl.so.1.1 (0x00007f6bd0b72000)
	libcrypto.so.1.1 => /lib/x86_64-linux-gnu/libcrypto.so.1.1 (0x00007f6bd089a000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f6bd0894000)
	libacl.so.1 => /lib/x86_64-linux-gnu/libacl.so.1 (0x00007f6bd0889000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f6bd087f000)
	libspdlog.so.1 => /lib/x86_64-linux-gnu/libspdlog.so.1 (0x00007f6bd07d6000)
	libexpat.so.1 => /lib/x86_64-linux-gnu/libexpat.so.1 (0x00007f6bd07a6000)
	libz.so.1 => /lib/x86_64-linux-gnu/libz.so.1 (0x00007f6bd078a000)
	libutil.so.1 => /lib/x86_64-linux-gnu/libutil.so.1 (0x00007f6bd0785000)
```

Seems like it's getting the ROS 2 libraries from RUNPATH

```console
$ readelf -d bazel-bin/bin_unaware_of_ros | grep RUNPATH
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN/_solib_k8/_U@ros2_S_S_Crclcpp_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Clibstatistics_Ucollector_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Cstd_Umsgs_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crcl_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crcl_Uinterfaces_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Ctracetools_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crmw_Uimplementation_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Cament_Uindex_Ucpp_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crcl_Ulogging_Uspdlog_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crcl_Ulogging_Uinterface_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Cstatistics_Umsgs_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crosgraph_Umsgs_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Cbuiltin_Uinterfaces_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crosidl_Utypesupport_Ucpp_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crosidl_Utypesupport_Uintrospection_Ucpp_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crosidl_Utypesupport_Uintrospection_Uc_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crosidl_Utypesupport_Uc_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crcpputils_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crcl_Uyaml_Uparam_Uparser_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Cyaml_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crmw_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crosidl_Uruntime_Uc_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Crcutils_Ucc___Uarchive_Slib:$ORIGIN/_solib_k8/_U@ros2_S_S_Clibyaml_Uvendor_Ucc___Uarchive_Slib:/home/osrf/.cache/bazel/_bazel_osrf/383f079a2635d21e3b905b3ffc908f7b/external/ros2/archive/lib]
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/114)
<!-- Reviewable:end -->
