### PR TITLE
Stop including entire ament index for each package

### DIFF
--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -108,16 +108,18 @@ def collect_ros_package_metadata(name, prefix):
 
     # Find any plugins provided by this package
     plugin_libraries = []
+    resource_markers = []
     for resource_type in os.listdir(resource_index_directory):
-        # Pluginlib adds this suffix to the ament index resource type
-        # https://github.com/ros/pluginlib/blob/
-        # a11ecea28a587637d51f036e0e04eb194b94abfe/pluginlib/cmake/
-        # pluginlib_package_hook.cmake#L22
-        if resource_type.endswith('__pluginlib__plugin'):
-            plugin_resource = os.path.join(
-                resource_index_directory, resource_type, name)
-            if os.path.exists(plugin_resource):
-                with open(plugin_resource, 'r') as fin:
+        resource_marker = os.path.join(
+            resource_index_directory, resource_type, name)
+        if os.path.exists(resource_marker):
+            resource_markers.append(resource_marker)
+            # Pluginlib adds this suffix to the ament index resource type
+            # https://github.com/ros/pluginlib/blob/
+            # a11ecea28a587637d51f036e0e04eb194b94abfe/pluginlib/cmake/
+            # pluginlib_package_hook.cmake#L22
+            if resource_marker.endswith('__pluginlib__plugin'):
+                with open(resource_marker, 'r') as fin:
                     path_to_desc = fin.read()
                 # Strip any trailing newline
                 path_to_desc = path_to_desc.strip()
@@ -128,5 +130,7 @@ def collect_ros_package_metadata(name, prefix):
                         path_to_desc)['plugin_libraries'])
     if plugin_libraries:
         metadata['plugin_libraries'] = plugin_libraries
+    if resource_markers:
+        metadata['ament_resource_marker_files'] = resource_markers
 
     return metadata

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/templates.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/templates.py
@@ -37,13 +37,15 @@ meta_py_name, meta_py_label = labels_with(suffix='_transitive_py')
 def configure_package_share_filegroup(name, metadata, sandbox):
     target_name = share_name(name, metadata)
     shared_directories = [sandbox(metadata['share_directory'])]
-    if 'ament_index_directory' in metadata:
-        shared_directories.append(sandbox(metadata['ament_index_directory']))
+    ament_resource_marker_files = [
+        sandbox(f) for f in metadata.get('ament_resource_marker_files', ())
+    ]
     return (
         target_name,
         load_resource('templates/package_share_filegroup.bazel.tpl'),
         to_starlark_string_dict({
-            'name': target_name, 'share_directories': shared_directories
+            'name': target_name, 'share_directories': shared_directories,
+            'ament_resource_marker_files': ament_resource_marker_files,
         })
     )
 

--- a/bazel_ros2_rules/ros2/resources/templates/package_share_filegroup.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_share_filegroup.bazel.tpl
@@ -1,4 +1,5 @@
 share_filegroup(
     name = @name@,
     share_directories = @share_directories@,
+    ament_resource_marker_files = @ament_resource_marker_files@,
 )

--- a/bazel_ros2_rules/ros2/tools/common.bzl
+++ b/bazel_ros2_rules/ros2/tools/common.bzl
@@ -2,7 +2,7 @@
 
 load("//:distro.bzl", "REPOSITORY_ROOT")
 
-def share_filegroup(name, share_directories):
+def share_filegroup(name, share_directories, ament_resource_marker_files):
     native.filegroup(
         name = name,
         srcs = [path for path in native.glob(
@@ -14,7 +14,9 @@ def share_filegroup(name, share_directories):
                 "*/*.bash",
                 "*/*.dsv",
             ]
-        ) if " " not in path],
+        ) if " " not in path] + [
+	    path for path in ament_resource_marker_files if " " not in path
+        ],
         # NOTE(hidmic): workaround lack of support for spaces.
         # See https://github.com/bazelbuild/bazel/issues/4327.
     )


### PR DESCRIPTION
The ament index design specs state that marker files in the resource index should share the name of the package installing them. We can leverage this to select which marker files belong to each package.

The existing approach worked for isolated workspace layouts, but broke down when inspecting a merged workspace.

https://github.com/ament/ament_cmake/blob/master/ament_cmake_core/doc/resource_index.md

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/123)
<!-- Reviewable:end -->
