### PR TITLE
rmw_isolation: Disable need for participant gain for cyclone dds

### DIFF
--- a/bazel_ros2_rules/ros2/resources/rmw_isolation/rmw_isolation.py
+++ b/bazel_ros2_rules/ros2/resources/rmw_isolation/rmw_isolation.py
@@ -158,7 +158,9 @@ def generate_isolated_rmw_cyclonedds_cpp_env(
     builder.data('0')  # ignore domain IDs
     builder.end('DomainGain')
     builder.start('ParticipantGain')
-    builder.data(str(PARTICIPANT_ID_GAIN))
+    # Ignore participant IDs given that we use PartcipantIndex="none". For more
+    # details, see drake-ros#125.
+    builder.data('0')
     builder.end('ParticipantGain')
     unicast_ports_offset = (
         ((digest[3] << 8) + digest[4]) % 2**10  # Use 10 bits


### PR DESCRIPTION
Should not be necessary given ParticipantIndex="none"

See #125

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/126)
<!-- Reviewable:end -->
