### PR TITLE
Process direct ament dependencies in a deterministic order

### DIFF
--- a/bazel_ros2_rules/ros2/generate_build_file.py
+++ b/bazel_ros2_rules/ros2/generate_build_file.py
@@ -107,7 +107,7 @@ def write_build_file(fd, repo_name, distro, sandbox, cache):
             )
         direct_dependencies = {
             dependency_name: distro['packages'][dependency_name]
-            for dependency_name in direct_dependency_names
+            for dependency_name in sorted(direct_dependency_names)
         }
 
         if 'share_directory' in metadata:


### PR DESCRIPTION
Python sets do not maintain any order information. Iterating over them may yield different orders among attempts.

The intermediate fallout from the nondeterministic processing of dependencies is that the include directory arguments passed to compiler invocations is related in some way to the order in which the dependencies are processed. This seems like a red flag to me, as we should be preserving the include order that was specified by the project's `CMakeLists.txt`, but the differences in ordering could be caused by de-duplication of paths based on their presence in dependencies.

Looking for thoughts on that.

Even if the order in `CMakeLists.txt` is being respected somehow, alphabetizing the dependencies seems arbitrary. Maybe topological order would be better, but I still feel like something is off here.

Resolves #116

```
$ bazel build //ros2_example_apps:talker_listener_cc_test
...
INFO: Elapsed time: 57.155s, Critical Path: 12.89s
INFO: 150 processes: 142 internal, 8 processwrapper-sandbox.
INFO: Build completed successfully, 150 total actions
$ bazel clean --expunge --async
$ bazel build //ros2_example_apps:talker_listener_cc_test
...
INFO: Elapsed time: 41.129s, Critical Path: 0.51s
INFO: 150 processes: 8 disk cache hit, 142 internal.
INFO: Build completed successfully, 150 total actions
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/128)
<!-- Reviewable:end -->
