### PR TITLE
Multiple fixes for CI builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: robotlocomotion/drake:focal
+    env:
+      LD_LIBRARY_PATH: /opt/drake/lib
     steps:
       - uses: ros-tooling/setup-ros@v0.2
         with:
@@ -27,6 +29,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: robotlocomotion/drake:focal
+    env:
+      LD_LIBRARY_PATH: /opt/drake/lib
     steps:
       - uses: ros-tooling/setup-ros@v0.2
       - name: Install dependencies to build ROS packages

--- a/ros2_example_bazel_installed/setup/prereq-rosdep-keys.txt
+++ b/ros2_example_bazel_installed/setup/prereq-rosdep-keys.txt
@@ -46,6 +46,7 @@ python3-lxml
 python3-mypy
 python3-netifaces
 python3-numpy
+python3-opencv
 python3-packaging
 python3-pkg-resources
 python3-psutil


### PR DESCRIPTION
There are currently two issues breaking CI builds for this repository:
1. [Set LD_LIBRARY_PATH=/opt/drake/lib in CI builds](https://github.com/RobotLocomotion/drake-ros/commit/6dbce12c21d30811beca2f81db089e22bf4e9a4b)

   Drake relies on RPATHs to locate dynamic libraries. ROS (and underlying Ubuntu libraries) do not use RPATHs when creating new dynamic binaries. Until recently, the Drake Docker images were setting LD_LIBRARY_PATH.

   Unfortunately, relying on only RPATHs forces downstream consumers to either also rely on RPATHs for finding the upstream (Drake, in this case) libraries, or they need to make the upstream libraries discoverable dynamically. The easiset way to do this is to either use the LD_LIBRARY_PATH environment variable (as ROS does) or modify ld.so.conf.

   This is a response to RobotLocomotion/drake#17846
3. [Update prereq-rosdep-keys.txt after changes to drake-ros-underlay](https://github.com/RobotLocomotion/drake-ros/commit/6104c6db5927e6559a0f05b0c46495751a267780)

   This is a response to ros2/ros_buildfarm_config#249

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/135)
<!-- Reviewable:end -->
