### PR TITLE
Add CI test against the ROS 2 Rolling archive for Focal

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,23 +33,31 @@ jobs:
         uses: ros-tooling/action-ros-ci@v0.2
         with:
           target-ros2-distro: ${{matrix.ros_distro}}
-  test_against_humble:
+  test_against_archive:
+    strategy:
+      matrix:
+        include:
+          - os_code_name: focal
+            ros_distro: rolling
+          - os_code_name: focal
+            ros_distro: humble
+    name: test_against_${{matrix.ros_distro}}_archive
     runs-on: ubuntu-latest
     container:
-      image: robotlocomotion/drake:focal
+      image: robotlocomotion/drake:${{matrix.os_code_name}}
     steps:
       - uses: ros-tooling/setup-ros@v0.4
       - name: Install dependencies to build ROS packages
         run: |
-          sudo mkdir -p /opt/ros/humble
-          wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci-CHECKSUM
-          wget -q http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-humble-linux-focal-amd64-ci.tar.bz2
-          sha256sum -c ros2-humble-linux-focal-amd64-ci-CHECKSUM
-          sudo tar xf ros2-humble-linux-focal-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/humble
-          sed -i 's|/tmp/ws/install_isolated|/opt/ros/humble|g' /opt/ros/humble/setup.sh
-          rm ros2-humble-linux-focal-amd64-ci.tar.bz2
+          sudo mkdir -p /opt/ros/${{matrix.ros_distro}}
+          wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci-CHECKSUM
+          wget -q http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2
+          sha256sum -c ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci-CHECKSUM
+          sudo tar xf ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/${{matrix.ros_distro}}
+          sed -i 's|/tmp/ws/install_isolated|/opt/ros/${{matrix.ros_distro}}|g' /opt/ros/${{matrix.ros_distro}}/setup.sh
+          rm ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2
           # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
-          rosdep update && rosdep install --from-paths /opt/ros/humble/share --ignore-src -y \
+          rosdep update && rosdep install --from-paths /opt/ros/${{matrix.ros_distro}}/share --ignore-src -y \
             -t exec -t buildtool_export -t build_export \
             --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp"
 
@@ -58,4 +66,4 @@ jobs:
       - name: Build and test all packages
         uses: ros-tooling/action-ros-ci@v0.2
         with:
-          target-ros2-distro: humble
+          target-ros2-distro: ${{matrix.ros_distro}}


### PR DESCRIPTION
Similar to #138 but for archive-based binaries for Focal.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/145)
<!-- Reviewable:end -->
