### PR TITLE
README: Update CI badge to show only CI results for main

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Drake ROS
 
-[![drake-ros continuous integration](https://github.com/RobotLocomotion/drake-ros/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/RobotLocomotion/drake-ros/actions/workflows/main.yml)
+[![drake-ros continuous integration](https://github.com/RobotLocomotion/drake-ros/actions/workflows/main.yml/badge.svg?branch=main)](https://github.com/RobotLocomotion/drake-ros/actions/workflows/main.yml?query=branch%3Amain)
 
 ## About
 


### PR DESCRIPTION
Otherwise, showed CI for all dev branches on upstream repo

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/152)
<!-- Reviewable:end -->
