### PR TITLE
Add Ament hook to put pydrake in PYTHONPATH

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,6 +23,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: robotlocomotion/drake:${{matrix.os_code_name}}
+    env:
+      PYTHONPATH:
     steps:
       - uses: ros-tooling/setup-ros@v0.4
         with:
@@ -45,6 +47,8 @@ jobs:
     runs-on: ubuntu-latest
     container:
       image: robotlocomotion/drake:${{matrix.os_code_name}}
+    env:
+      PYTHONPATH:
     steps:
       - uses: ros-tooling/setup-ros@v0.4
       - name: Install dependencies to build ROS packages

--- a/drake_ros_core/CMakeLists.txt
+++ b/drake_ros_core/CMakeLists.txt
@@ -74,23 +74,10 @@ set(
 ament_environment_hooks("env-hooks/drake_library_path.sh.in")
 
 ### Python module path environment hook for pydrake
-find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+ament_get_python_install_dir(PYTHON_INSTALL_DIR)
 get_filename_component(DRAKE_INSTALL_PREFIX ${DRAKE_LIBRARY_DIR} DIRECTORY)
-set(_python_code
-  "import sysconfig"
-  "print(sysconfig.get_path('purelib', vars={'base': '${DRAKE_INSTALL_PREFIX}'}))"
-)
-execute_process(
-  COMMAND "${PYTHON_EXECUTABLE}" "-c" "${_python_code}"
-  OUTPUT_VARIABLE PYDRAKE_PYTHONPATH
-  RESULT_VARIABLE _result
-  OUTPUT_STRIP_TRAILING_WHITESPACE
-)
-if(NOT _result EQUAL 0)
-  message(FATAL_ERROR
-    "execute_process(${_python_interpreter} -c '${_python_code}') returned "
-    "error code ${_result}")
-endif()
+get_filename_component(PYDRAKE_PYTHONPATH ${DRAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR} ABSOLUTE)
 set(
   AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_pydrake_pythonpath
   "prepend-non-duplicate;PYTHONPATH;${PYDRAKE_PYTHONPATH}")

--- a/drake_ros_core/CMakeLists.txt
+++ b/drake_ros_core/CMakeLists.txt
@@ -73,6 +73,29 @@ set(
   "prepend-non-duplicate;${LIBRARY_PATH_ENV_VAR};${DRAKE_LIBRARY_DIR}")
 ament_environment_hooks("env-hooks/drake_library_path.sh.in")
 
+### Python module path environment hook for pydrake
+find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
+get_filename_component(DRAKE_INSTALL_PREFIX ${DRAKE_LIBRARY_DIR} DIRECTORY)
+set(_python_code
+  "import sysconfig"
+  "print(sysconfig.get_path('purelib', vars={'base': '${DRAKE_INSTALL_PREFIX}'}))"
+)
+execute_process(
+  COMMAND "${PYTHON_EXECUTABLE}" "-c" "${_python_code}"
+  OUTPUT_VARIABLE PYDRAKE_PYTHONPATH
+  RESULT_VARIABLE _result
+  OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+if(NOT _result EQUAL 0)
+  message(FATAL_ERROR
+    "execute_process(${_python_interpreter} -c '${_python_code}') returned "
+    "error code ${_result}")
+endif()
+set(
+  AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_pydrake_pythonpath
+  "prepend-non-duplicate;PYTHONPATH;${PYDRAKE_PYTHONPATH}")
+ament_environment_hooks("env-hooks/pydrake_pythonpath.sh.in")
+
 # Nominal ament install directives
 install(TARGETS ${PROJECT_NAME} EXPORT ${PROJECT_NAME}
   ARCHIVE DESTINATION lib

--- a/drake_ros_core/CMakeLists.txt
+++ b/drake_ros_core/CMakeLists.txt
@@ -74,13 +74,9 @@ set(
 ament_environment_hooks("env-hooks/drake_library_path.sh.in")
 
 ### Python module path environment hook for pydrake
-find_package(ament_cmake_python REQUIRED)
-ament_get_python_install_dir(PYTHON_INSTALL_DIR)
-get_filename_component(DRAKE_INSTALL_PREFIX ${DRAKE_LIBRARY_DIR} DIRECTORY)
-get_filename_component(PYDRAKE_PYTHONPATH ${DRAKE_INSTALL_PREFIX}/${PYTHON_INSTALL_DIR} ABSOLUTE)
 set(
   AMENT_CMAKE_ENVIRONMENT_HOOKS_DESC_pydrake_pythonpath
-  "prepend-non-duplicate;PYTHONPATH;${PYDRAKE_PYTHONPATH}")
+  "prepend-non-duplicate;PYTHONPATH;${drake_PYTHON_DIR}")
 ament_environment_hooks("env-hooks/pydrake_pythonpath.sh.in")
 
 # Nominal ament install directives

--- a/drake_ros_core/env-hooks/pydrake_pythonpath.sh.in
+++ b/drake_ros_core/env-hooks/pydrake_pythonpath.sh.in
@@ -1,0 +1,5 @@
+# Generated from template at drake_ros_core/env-hooks/pydrake_pythonpath.sh.in
+
+# Ensures the pydrake Python module can be found at runtime.
+# See RobotLocomotion/drake-ros#157 for more details.
+ament_prepend_unique_value "PYTHONPATH" "@PYDRAKE_PYTHONPATH@"

--- a/drake_ros_core/env-hooks/pydrake_pythonpath.sh.in
+++ b/drake_ros_core/env-hooks/pydrake_pythonpath.sh.in
@@ -2,4 +2,4 @@
 
 # Ensures the pydrake Python module can be found at runtime.
 # See RobotLocomotion/drake-ros#157 for more details.
-ament_prepend_unique_value "PYTHONPATH" "@PYDRAKE_PYTHONPATH@"
+ament_prepend_unique_value "PYTHONPATH" "@drake_PYTHON_DIR@"

--- a/drake_ros_core/package.xml
+++ b/drake_ros_core/package.xml
@@ -15,6 +15,7 @@
   https://github.com/ros2/eigen3_cmake_module
   -->
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <build_depend>ament_cmake_python</build_depend>
   <build_depend>eigen</build_depend>
 
   <depend>rclcpp</depend>

--- a/drake_ros_core/package.xml
+++ b/drake_ros_core/package.xml
@@ -15,7 +15,6 @@
   https://github.com/ros2/eigen3_cmake_module
   -->
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
-  <build_depend>ament_cmake_python</build_depend>
   <build_depend>eigen</build_depend>
 
   <depend>rclcpp</depend>


### PR DESCRIPTION
~~This change borrows from the `PYTHONPATH` hook creation mechanism used in `ament_cmake_core`.~~

~~It makes the following assumptions:~~
~~1. Drake installs Python modules to `platlib`, and not `purelib`~~
~~2. Drake installs Python modules to the same prefix as `libdrake.so`~~
~~3. Drake uses the same Python interpreter version as the system's default~~

~~Closes #157~~
~~Related to #143~~

Requires RobotLocomotion/drake#18201

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/160)
<!-- Reviewable:end -->
