### PR TITLE
Ensure C/C++ Python libraries are included in scraped packages

### DIFF
--- a/bazel_ros2_rules/ros2/resources/ros2bzl/templates.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/templates.py
@@ -174,7 +174,7 @@ def configure_package_py_library(
     if 'cc' in metadata.get('langs', []):
         data.append(cc_label(name, metadata))
 
-    if properties.cc_extensions:
+    if properties.cc_extensions or properties.cc_libraries:
         # Bring in C/C++ dependencies
         cc_deps = [
             cc_label(dependency_name, dependency_metadata)

--- a/ros2_example_bazel_installed/BUILD.bazel
+++ b/ros2_example_bazel_installed/BUILD.bazel
@@ -61,3 +61,10 @@ py_test(
         ":shimmed_sentinel_py",
     ],
 )
+
+ros_py_test(
+    name = "tf2_py_import_test",
+    srcs = ["test/tf2_py_import_test.py"],
+    main = "test/tf2_py_import_test.py",
+    deps = ["@ros2//:tf2_py_py"],
+)

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -46,6 +46,7 @@ ROS2_PACKAGES = [
     "rclpy",
     "ros2cli",
     "ros2cli_common_extensions",
+    "tf2_py",
 ] + [
     # These are possible RMW implementations. Uncomment one and only one to
     # change implementations

--- a/ros2_example_bazel_installed/test/tf2_py_import_test.py
+++ b/ros2_example_bazel_installed/test/tf2_py_import_test.py
@@ -1,0 +1,5 @@
+"""
+Ensures we can import tf2_py per drake-ros#177.
+"""
+
+import tf2_py


### PR DESCRIPTION
This should resolve a regression where C/C++ libraries were dropped from the file list for Python packages, resulting in import errors.

Regression caused by #150
Includes #178 to demonstrate the fix
Resolves #177

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/181)
<!-- Reviewable:end -->
