### PR TITLE
Only consider system directories that exist

### DIFF
--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/system.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/system.py
@@ -38,7 +38,8 @@ def system_link_dirs():
     ).stdout.strip()
 
     for directory in re.findall(r'SEARCH_DIR\("=([^=]+)"\)', output):
-        link_dirs.add(directory)
+        if os.path.isdir(directory):
+            link_dirs.add(directory)
     # Filter empty strings
     return tuple([d for d in link_dirs if d])
 
@@ -55,8 +56,9 @@ def system_shared_lib_dirs():
         encoding='utf8'
     ).stdout.strip()
 
-    for directory in re.findall(r'([^:\t\n]+):', output):
-        lib_dirs.add(directory)
+    for directory in re.findall(r'(/[^:\t\n]+):', output):
+        if os.path.isdir(directory):
+            lib_dirs.add(directory)
     # Workaround Singularity redirects, e.g. for `--nv`.
     lib_dirs.add("/.singularity.d/libs")
     # Filter empty strings


### PR DESCRIPTION
This fixes a couple issues I noticed while debugging `bazel_ros2_rules` on Jammy. I'm not done debugging yet, but these two are easy ones I think can go in now.

The first is the regex looking for directoriers in the output of `ldconfig -XN --verbose` was not specific enough. It was matching warning messages and config files as if they were link directories. I fixed this by requiring `/` as the first character, and then checking that the directory actually exists.

The second issue is the output of `ld --verbose` included some search directories that don't exist. This doesn't seem to matter, but it adds extra stuff to look through when debugging.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/185)
<!-- Reviewable:end -->
