### PR TITLE
Workaround rviz_ogre_vendor not finding RenderSystem_GL.so

### DIFF
--- a/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
+++ b/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
@@ -7,6 +7,12 @@ cmake_minimum_required(VERSION 3.5)
 project(@NAME@ C CXX)
 
 find_package(ament_cmake REQUIRED)
+
+# TODO(sloretz) Remove when fixed upstream
+if("@PACKAGE@" STREQUAL "rviz_ogre_vendor")
+  set(CMAKE_FIND_LIBRARY_PREFIXES ";lib")
+endif()
+
 find_package(@PACKAGE@ REQUIRED)
 
 file(WRITE empty.cc "")

--- a/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
+++ b/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
@@ -8,7 +8,7 @@ project(@NAME@ C CXX)
 
 find_package(ament_cmake REQUIRED)
 
-# TODO(sloretz) Remove when fixed upstream
+# TODO(sloretz) Remove when https://github.com/ros2/rviz/pull/920 is released
 if("@PACKAGE@" STREQUAL "rviz_ogre_vendor")
   set(CMAKE_FIND_LIBRARY_PREFIXES ";lib")
 endif()


### PR DESCRIPTION
This fixes one last issue when using the tarball from https://build.ros2.org/view/Hci/job/Hci__nightly-cyclonedds_ubuntu_jammy_amd64/

The same issue happens on [the ROS 2 buildfarm](https://build.ros2.org/job/Hbin_uJ64__rviz_rendering__ubuntu_jammy_amd64__binary/8/consoleText), but nothing is trying to use those targets so it's gone unnoticed. It went noticed here because the `bazel_ros2_rules` was trying to look for the libraries from those targets so that it could include them in the sandboxing. I'll also open a PR with a fix upstream.

This is the source of the console spam in Anzu.

EDIT: See https://github.com/ros2/rviz/pull/920 for discussion and root-cause analysis (most likely a breaking CMake change)


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/188)
<!-- Reviewable:end -->
