### PR TITLE
Use System.ForcedPublish in lieu of deprecated System.Publish

### DIFF
--- a/drake_ros_examples/examples/multirobot/multirobot.cc
+++ b/drake_ros_examples/examples/multirobot/multirobot.cc
@@ -129,7 +129,7 @@ int main() {
   while (true) {
     simulator->AdvanceTo(simulator_context.get_time() + 0.1);
     // At each time step, trigger the publication of the diagram's outputs
-    diagram->Publish(simulator_context);
+    diagram->ForcedPublish(simulator_context);
   }
 
   return 0;

--- a/drake_ros_examples/examples/multirobot/multirobot.py
+++ b/drake_ros_examples/examples/multirobot/multirobot.py
@@ -120,4 +120,4 @@ if __name__ == '__main__':
     while True:
         simulator.AdvanceTo(simulator_context.get_time() + 0.1)
         # At each time step, trigger the publication of the diagram's outputs
-        diagram.Publish(simulator_context)
+        diagram.ForcedPublish(simulator_context)

--- a/drake_ros_tf2/test/test_tf_broadcaster.cc
+++ b/drake_ros_tf2/test/test_tf_broadcaster.cc
@@ -101,7 +101,7 @@ TEST(SceneTfBroadcasting, NominalCase) {
   const auto time = rclcpp::Time() + rclcpp::Duration::from_seconds(13.);
 
   context->SetTime(time.seconds());
-  diagram->Publish(*context);
+  diagram->ForcedPublish(*context);
   rclcpp::spin_some(node);
 
   EXPECT_TRUE(buffer.canTransform("world", "odom", time));

--- a/drake_ros_tf2/test/test_tf_broadcaster.py
+++ b/drake_ros_tf2/test/test_tf_broadcaster.py
@@ -96,7 +96,7 @@ def test_nominal_case():
     stamp = time.to_msg()
 
     context.SetTime(time.nanoseconds / 1e9)
-    diagram.Publish(context)
+    diagram.ForcedPublish(context)
 
     future = buffer_.wait_for_transform_async('world', 'odom', time)
     rclpy.spin_until_future_complete(node, future, timeout_sec=2)


### PR DESCRIPTION
As of Drake PR ([#18106](https://github.com/RobotLocomotion/drake/pull/18106)), usage of `Publish` should be `ForcedPublish` As of now, `drake-ros` builds fail.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/190)
<!-- Reviewable:end -->
