### PR TITLE
Fix bazel_ros2_rules handling of console bridge

### DIFF
--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_cmake.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_cmake.py
@@ -67,6 +67,10 @@ def collect_ament_cmake_shared_library_codemodel(
             if is_system_library(library):
                 if library.startswith('/usr/local'):
                     local_link_libraries.append(library)
+                if os.path.basename(library).startswith("libconsole_bridge"):
+                    # Special case console_bridge system package on Jammy
+                    link_flags.append('-L' + os.path.dirname(library))
+                    link_flags.append('-l:' + os.path.basename(library))
                 continue
             link_libraries.append(library)
     # Fail on any /usr/local libraries

--- a/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
+++ b/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
@@ -13,6 +13,7 @@ if("@PACKAGE@" STREQUAL "rviz_ogre_vendor")
   set(CMAKE_FIND_LIBRARY_PREFIXES ";lib")
 endif()
 
+
 find_package(@PACKAGE@ REQUIRED)
 
 file(WRITE empty.cc "")
@@ -37,6 +38,11 @@ if("@PACKAGE@" STREQUAL "rviz_ogre_vendor")
   )
   file(GLOB ogre_plugin_libraries "${OGRE_PLUGIN_DIR}/*.so*")
   target_link_libraries(${PROJECT_NAME} ${ogre_plugin_libraries})
+elseif("@PACKAGE@" STREQUAL "console_bridge_vendor")
+  # TODO(sloretz) How to get targets from externalproject_add based vendor
+  # packages?
+  find_package(console_bridge REQUIRED)
+  target_link_libraries(${PROJECT_NAME} console_bridge::console_bridge)
 else()
   ament_target_dependencies(${PROJECT_NAME} @PACKAGE@)
   # TODO(hidmic): figure out why this is sometimes necessary

--- a/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
+++ b/bazel_ros2_rules/ros2/resources/templates/ament_cmake_CMakeLists.txt.in
@@ -13,7 +13,6 @@ if("@PACKAGE@" STREQUAL "rviz_ogre_vendor")
   set(CMAKE_FIND_LIBRARY_PREFIXES ";lib")
 endif()
 
-
 find_package(@PACKAGE@ REQUIRED)
 
 file(WRITE empty.cc "")

--- a/ros2_example_bazel_installed/BUILD.bazel
+++ b/ros2_example_bazel_installed/BUILD.bazel
@@ -68,3 +68,9 @@ ros_py_test(
     main = "test/tf2_py_import_test.py",
     deps = ["@ros2//:tf2_py_py"],
 )
+
+ros_cc_test(
+    name = "console_bridge_test",
+    srcs = ["test/use_console_bridge.cc"],
+    deps = ["@ros2//:console_bridge_vendor_cc"],
+)

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -37,17 +37,18 @@ add_bazel_ros2_rules_dependencies()
 load("@bazel_ros2_rules//ros2:defs.bzl", "ros2_archive")
 load("@bazel_ros2_rules//ros2:defs.bzl", "ros2_local_repository")
 
+# Please keep this list sorted
 ROS2_PACKAGES = [
     "action_msgs",
     "builtin_interfaces",
-    "rosidl_default_generators",
-    "rclcpp_action",
+    "console_bridge_vendor",
     "rclcpp",
+    "rclcpp_action",
     "rclpy",
     "ros2cli",
     "ros2cli_common_extensions",
+    "rosidl_default_generators",
     "tf2_py",
-    "console_bridge_vendor",
 ] + [
     # These are possible RMW implementations. Uncomment one and only one to
     # change implementations

--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -47,6 +47,7 @@ ROS2_PACKAGES = [
     "ros2cli",
     "ros2cli_common_extensions",
     "tf2_py",
+    "console_bridge_vendor",
 ] + [
     # These are possible RMW implementations. Uncomment one and only one to
     # change implementations

--- a/ros2_example_bazel_installed/test/use_console_bridge.cc
+++ b/ros2_example_bazel_installed/test/use_console_bridge.cc
@@ -1,0 +1,7 @@
+#include <console_bridge/console.h>
+
+int main()
+{
+  CONSOLE_BRIDGE_logWarn("%s", "Hello world!");
+  return 0;
+}


### PR DESCRIPTION
The `@ros2//:console_bridge_vendor_cc` wasn't including any libraries to link on either Focal or Jammy. 

The first problem applies to both Focal and Jammy. The `bazel_ros2_rules` package assumes any found package will have CMake targets to link against, but the `console_bridge_vendor` doesn't have any. It expects users to `find_package(console_bridge)` and use that instead. This is fixed with a special case in the `ament_cmake_CMakeLists.txt` template to use `console_bridge` when `console_bridge_vendor` is requested.

The second problem applies only to`bazel_ros2_rules` on Jammy. The vendor package [uses the system package on Jammy because the version is new enough](https://github.com/ros2/console_bridge_vendor/blob/44389a5e8205fd3040c0ef8d0c452ac671786d09/CMakeLists.txt#L100-L105). However, the `libconsole_bridge.so*` library is filtered out as it's a system dependency. The fix is to add a special case using `-L` and `-l:` as link flags instead of filtering the library out altogether.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/195)
<!-- Reviewable:end -->
