### PR TITLE
Upgrade gtest to fix breaking bazel change

### DIFF
--- a/drake_ros_core/WORKSPACE
+++ b/drake_ros_core/WORKSPACE
@@ -4,10 +4,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_googletest",
-    sha256 = "5cf189eb6847b4f8fc603a3ffff3b0771c08eec7dd4bd961bfd45477dd13eb73",  # noqa
-    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",  # noqa
+    sha256 = "fbc8efdca4238e7dbe0642e29911a77be393f191a2444fa10372ee99bb665125",  # noqa
+    strip_prefix = "googletest-1.12.0",  # noqa
     urls = [
-        "https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip",  # noqa
+        "https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip",  # noqa
     ],
 )
 

--- a/drake_ros_tf2/WORKSPACE
+++ b/drake_ros_tf2/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_googletest",
-    sha256 = "5cf189eb6847b4f8fc603a3ffff3b0771c08eec7dd4bd961bfd45477dd13eb73",  # noqa
-    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
-    urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],  # noqa
+    sha256 = "fbc8efdca4238e7dbe0642e29911a77be393f191a2444fa10372ee99bb665125",  # noqa
+    strip_prefix = "googletest-1.12.0",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip"],  # noqa
 )
 
 # Use the ROS 2 bazel rules

--- a/drake_ros_viz/WORKSPACE
+++ b/drake_ros_viz/WORKSPACE
@@ -4,9 +4,9 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 http_archive(
     name = "com_google_googletest",
-    sha256 = "5cf189eb6847b4f8fc603a3ffff3b0771c08eec7dd4bd961bfd45477dd13eb73",  # noqa
-    strip_prefix = "googletest-609281088cfefc76f9d0ce82e1ff6c30cc3591e5",
-    urls = ["https://github.com/google/googletest/archive/609281088cfefc76f9d0ce82e1ff6c30cc3591e5.zip"],  # noqa
+    sha256 = "fbc8efdca4238e7dbe0642e29911a77be393f191a2444fa10372ee99bb665125",  # noqa
+    strip_prefix = "googletest-1.12.0",
+    urls = ["https://github.com/google/googletest/archive/refs/tags/v1.12.0.zip"],  # noqa
 )
 
 # Use the ROS 2 bazel rules


### PR DESCRIPTION
Noticed in #189 

Bazel can no longer build the version of gtest specified by `drake_ros_core`, `drake_ros_viz`, and `drake_ros_tf2`. 

```
ERROR: /home/runner/.cache/bazel/_bazel_runner/028206ac998ad78d07e8acc492e5bd46/external/bazel_tools/platforms/BUILD:89:6: in alias rule @bazel_tools//platforms:windows: Constraints from @bazel_tools//platforms have been removed. Please use constraints from @platforms repository embedded in Bazel, or preferably declare dependency on https://github.com/bazelbuild/platforms. See https://github.com/bazelbuild/bazel/issues/8622 for details.
ERROR: /home/runner/.cache/bazel/_bazel_runner/028206ac998ad78d07e8acc492e5bd46/external/bazel_tools/platforms/BUILD:89:6: Analysis of target '@bazel_tools//platforms:windows' failed
INFO: Repository remote_coverage_tools instantiated at:
  /DEFAULT.WORKSPACE.SUFFIX:4:6: in <toplevel>
  /home/runner/.cache/bazel/_bazel_runner/028206ac998ad78d07e8acc492e5bd46/external/bazel_tools/tools/build_defs/repo/utils.bzl:233:18: in maybe
Repository rule http_archive defined at:
  /home/runner/.cache/bazel/_bazel_runner/028206ac998ad78d07e8acc492e5bd46/external/bazel_tools/tools/build_defs/repo/http.bzl:372:31: in <toplevel>
ERROR: /home/runner/.cache/bazel/_bazel_runner/028206ac998ad78d07e8acc492e5bd46/external/com_google_googletest/BUILD.bazel:116:11: errors encountered resolving select() keys for @com_google_googletest//:gtest_main
```

https://github.com/RobotLocomotion/drake-ros/actions/runs/3802593789/jobs/6468228156

There's something unusual in that the breaking change was supposed to be in bazel 6, but the job in question says it installed bazel 5.3.1.

```
2022-12-29 19:15:28 (81.5 MB/s) - ‘/tmp/bazel_5.3.1-amd64.deb’ saved [48640608/48640608]

/tmp/bazel_5.3.1-amd64.deb: OK

Selecting previously unselected package bazel.
(Reading database ... 273581 files and directories currently installed.)
Preparing to unpack /tmp/bazel_5.3.1-amd64.deb ...
Unpacking bazel (5.3.1) ...
Setting up bazel (5.3.1) ...
install_prereqs: success
```

Maybe CI is also installing bazel 6.0 somehow?

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/204)
<!-- Reviewable:end -->
