### PR TITLE
Switch to official Jammy tarballs in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - os_code_name: focal
+          - os_code_name: jammy
             ros_distro: rolling
-          - os_code_name: focal
+          - os_code_name: jammy
             ros_distro: humble
     name: test_against_${{matrix.ros_distro}}_archive
     runs-on: ubuntu-latest
@@ -52,14 +52,15 @@ jobs:
       - name: Install dependencies to build ROS packages
         run: |
           sudo mkdir -p /opt/ros/${{matrix.ros_distro}}
-          wget -q https://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci-CHECKSUM
-          wget -q http://repo.ros2.org/ci_archives/drake-ros-underlay/ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2
+          wget -q https://repo.ros2.org/ci_archives/nightly-cyclonedds/ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci-CHECKSUM
+          wget -q http://repo.ros2.org/ci_archives/nightly-cyclonedds/ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2
           sha256sum -c ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci-CHECKSUM
           sudo tar xf ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2 --strip-components=1 -C /opt/ros/${{matrix.ros_distro}}
           sed -i 's|/tmp/ws/install_isolated|/opt/ros/${{matrix.ros_distro}}|g' /opt/ros/${{matrix.ros_distro}}/setup.sh
           rm ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2
           # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
-          rosdep update && rosdep install --from-paths /opt/ros/${{matrix.ros_distro}}/share --ignore-src -y \
+          SHARE_DIRS=`find /opt/ros/${{matrix.ros_distro}} -maxdepth 2 -name share -type d`
+          rosdep update && rosdep install --from-paths $SHARE_DIRS --ignore-src -y \
             -t exec -t buildtool_export -t build_export \
             --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp"
 


### PR DESCRIPTION
Start using official nightly archives which target Ubuntu Jammy in place of bespoke Focal tarballs.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/robotlocomotion/drake-ros/206)
<!-- Reviewable:end -->
