### PR TITLE
Fix for eigen3 not found error in an isolated workspace

### DIFF
--- a/drake_ros_core/package.xml
+++ b/drake_ros_core/package.xml
@@ -30,9 +30,10 @@
   <test_depend>ament_cmake_pytest</test_depend>
   <test_depend>test_msgs</test_depend>
 
+  <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
+  <build_export_depend>eigen</build_export_depend>
+
   <export>
     <build_type>ament_cmake</build_type>
-    <buildtool_export_depend>eigen3_cmake_module</buildtool_export_depend>
-    <build_export_depend>eigen</build_export_depend>
   </export>
 </package>


### PR DESCRIPTION
When building in an isolated workspace, CMake cannot find eigen3, as ``buildtool_export_depend`` tag is in the wrong place.
This fixes it.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/209)
<!-- Reviewable:end -->
