### PR TITLE
Update for Rolling PublisherBase and SubscriptionBase API change

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,9 +60,10 @@ jobs:
           rm ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2
           # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
           SHARE_DIRS=`find /opt/ros/${{matrix.ros_distro}} -maxdepth 2 -name share -type d`
+          # TODO(sloretz) remove rosbag2_performance_benchmarking_msgs when https://github.com/ros2/rosbag2/pull/1242 lands
           rosdep update && rosdep install --from-paths $SHARE_DIRS --ignore-src -y \
             -t exec -t buildtool_export -t build_export \
-            --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp"
+            --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp rosbag2_performance_benchmarking_msgs"
 
       - name: Cope with Python 2 pollution
         run: apt-get update && apt-get install -y python-is-python3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -60,7 +60,7 @@ jobs:
           rm ros2-${{matrix.ros_distro}}-linux-${{matrix.os_code_name}}-amd64-ci.tar.bz2
           # TODO(sloretz) Use bazel_ros2_rules/ros2/compute_system_rosdeps.py to de-duplicate rosdep invocation knowledge
           SHARE_DIRS=`find /opt/ros/${{matrix.ros_distro}} -maxdepth 2 -name share -type d`
-          # TODO(sloretz) remove rosbag2_performance_benchmarking_msgs when https://github.com/ros2/rosbag2/pull/1242 lands
+          # TODO(sloretz) remove --skip-keys for rosbag2_performance_benchmarking_msgs when https://github.com/ros2/rosbag2/pull/1242 lands
           rosdep update && rosdep install --from-paths $SHARE_DIRS --ignore-src -y \
             -t exec -t buildtool_export -t build_export \
             --skip-keys "cyclonedds fastcdr fastrtps rmw_connextdds rmw_cyclonedds_cpp rmw_fastrtps_dynamic_cpp rti-connext-dds-5.3.1 urdfdom_headers iceoryx_binding_c rosidl_typesupport_fastrtps_c rosidl_typesupport_fastrtps_cpp rosbag2_performance_benchmarking_msgs"

--- a/drake_ros_core/src/publisher.cc
+++ b/drake_ros_core/src/publisher.cc
@@ -29,17 +29,20 @@ rcl_publisher_options_t publisher_options(const rclcpp::QoS& qos) {
 }
 }  // namespace
 
-Publisher::Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
-                     const rosidl_message_type_support_t& type_support,
-                     const std::string& topic_name, const rclcpp::QoS& qos)
-    : rclcpp::PublisherBase(node_base, topic_name, type_support,
+Publisher::Publisher(
+    rclcpp::node_interfaces::NodeBaseInterface* node_base,
+    const rosidl_message_type_support_t& type_support,
+    const std::string& topic_name, const rclcpp::QoS& qos)
 #if RCLCPP_VERSION_GTE(18, 0, 0)
-                            publisher_options(qos), {}, true) {
-}
+    : rclcpp::PublisherBase(
+        node_base, topic_name, type_support, publisher_options(qos),
+        /* event_callbacks */ {},
+        /* use_default_callbacks */ true)
 #else
-                            publisher_options(qos)) {
-}
+    : rclcpp::PublisherBase(
+        node_base, topic_name, type_support, publisher_options(qos))
 #endif
+{ }
 
 Publisher::~Publisher() {}
 

--- a/drake_ros_core/src/publisher.cc
+++ b/drake_ros_core/src/publisher.cc
@@ -31,20 +31,15 @@ rcl_publisher_options_t publisher_options(const rclcpp::QoS& qos) {
 
 Publisher::Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
                      const rosidl_message_type_support_t& type_support,
-                     const std::string& topic_name, const rclcpp::QoS& qos,
-                     const rclcpp::PublisherOptionsBase& options)
+                     const std::string& topic_name, const rclcpp::QoS& qos)
+    : rclcpp::PublisherBase(node_base, topic_name, type_support,
 #if RCLCPP_VERSION_GTE(18, 0, 0)
-    : rclcpp::PublisherBase(node_base, topic_name, type_support,
-                            publisher_options(qos), options.event_callbacks,
-                            options.use_default_callbacks){}
+                            publisher_options(qos), {}, true) {}
 #else
-    : rclcpp::PublisherBase(node_base, topic_name, type_support,
-                            publisher_options(qos)) {
-}
+                            publisher_options(qos)) {}
 #endif
 
-      Publisher::~Publisher() {
-}
+Publisher::~Publisher() {}
 
 void Publisher::publish(const rclcpp::SerializedMessage& serialized_msg) {
   // TODO(sloretz) Copied from rosbag2_transport GenericPublisher, can it be

--- a/drake_ros_core/src/publisher.cc
+++ b/drake_ros_core/src/publisher.cc
@@ -16,6 +16,8 @@
 
 #include <string>
 
+#include <rclcpp/version.h>
+
 namespace drake_ros_core {
 namespace internal {
 namespace {
@@ -29,11 +31,20 @@ rcl_publisher_options_t publisher_options(const rclcpp::QoS& qos) {
 
 Publisher::Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
                      const rosidl_message_type_support_t& type_support,
-                     const std::string& topic_name, const rclcpp::QoS& qos)
+                     const std::string& topic_name, const rclcpp::QoS& qos,
+                     const rclcpp::PublisherOptionsBase& options)
+#if RCLCPP_VERSION_GTE(18, 0, 0)
     : rclcpp::PublisherBase(node_base, topic_name, type_support,
-                            publisher_options(qos)) {}
+                            publisher_options(qos), options.event_callbacks,
+                            options.use_default_callbacks){}
+#else
+    : rclcpp::PublisherBase(node_base, topic_name, type_support,
+                            publisher_options(qos)) {
+}
+#endif
 
-Publisher::~Publisher() {}
+      Publisher::~Publisher() {
+}
 
 void Publisher::publish(const rclcpp::SerializedMessage& serialized_msg) {
   // TODO(sloretz) Copied from rosbag2_transport GenericPublisher, can it be

--- a/drake_ros_core/src/publisher.cc
+++ b/drake_ros_core/src/publisher.cc
@@ -34,9 +34,11 @@ Publisher::Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
                      const std::string& topic_name, const rclcpp::QoS& qos)
     : rclcpp::PublisherBase(node_base, topic_name, type_support,
 #if RCLCPP_VERSION_GTE(18, 0, 0)
-                            publisher_options(qos), {}, true) {}
+                            publisher_options(qos), {}, true) {
+}
 #else
-                            publisher_options(qos)) {}
+                            publisher_options(qos)) {
+}
 #endif
 
 Publisher::~Publisher() {}

--- a/drake_ros_core/src/publisher.cc
+++ b/drake_ros_core/src/publisher.cc
@@ -29,20 +29,20 @@ rcl_publisher_options_t publisher_options(const rclcpp::QoS& qos) {
 }
 }  // namespace
 
-Publisher::Publisher(
-    rclcpp::node_interfaces::NodeBaseInterface* node_base,
-    const rosidl_message_type_support_t& type_support,
-    const std::string& topic_name, const rclcpp::QoS& qos)
+Publisher::Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
+                     const rosidl_message_type_support_t& type_support,
+                     const std::string& topic_name, const rclcpp::QoS& qos)
 #if RCLCPP_VERSION_GTE(18, 0, 0)
-    : rclcpp::PublisherBase(
-        node_base, topic_name, type_support, publisher_options(qos),
-        /* event_callbacks */ {},
-        /* use_default_callbacks */ true)
+    : rclcpp::PublisherBase(node_base, topic_name, type_support,
+                            publisher_options(qos),
+                            /* event_callbacks */ {},
+                            /* use_default_callbacks */ true)
 #else
-    : rclcpp::PublisherBase(
-        node_base, topic_name, type_support, publisher_options(qos))
+    : rclcpp::PublisherBase(node_base, topic_name, type_support,
+                            publisher_options(qos))
 #endif
-{ }
+{
+}
 
 Publisher::~Publisher() {}
 

--- a/drake_ros_core/src/publisher.h
+++ b/drake_ros_core/src/publisher.h
@@ -17,7 +17,6 @@
 #include <string>
 
 #include <rclcpp/publisher_base.hpp>
-#include <rclcpp/publisher_options.hpp>
 #include <rclcpp/qos.hpp>
 #include <rclcpp/serialized_message.hpp>
 #include <rosidl_runtime_c/message_type_support_struct.h>
@@ -30,13 +29,7 @@ class Publisher final : public rclcpp::PublisherBase {
  public:
   Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
             const rosidl_message_type_support_t& ts,
-            const std::string& topic_name, const rclcpp::QoS& qos)
-      : Publisher(node_base, ts, topic_name, qos, {}) {}
-
-  Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
-            const rosidl_message_type_support_t& ts,
-            const std::string& topic_name, const rclcpp::QoS& qos,
-            const rclcpp::PublisherOptionsBase& options);
+            const std::string& topic_name, const rclcpp::QoS& qos);
 
   ~Publisher();
 

--- a/drake_ros_core/src/publisher.h
+++ b/drake_ros_core/src/publisher.h
@@ -17,6 +17,7 @@
 #include <string>
 
 #include <rclcpp/publisher_base.hpp>
+#include <rclcpp/publisher_options.hpp>
 #include <rclcpp/qos.hpp>
 #include <rclcpp/serialized_message.hpp>
 #include <rosidl_runtime_c/message_type_support_struct.h>
@@ -29,7 +30,13 @@ class Publisher final : public rclcpp::PublisherBase {
  public:
   Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
             const rosidl_message_type_support_t& ts,
-            const std::string& topic_name, const rclcpp::QoS& qos);
+            const std::string& topic_name, const rclcpp::QoS& qos)
+      : Publisher(node_base, ts, topic_name, qos, {}) {}
+
+  Publisher(rclcpp::node_interfaces::NodeBaseInterface* node_base,
+            const rosidl_message_type_support_t& ts,
+            const std::string& topic_name, const rclcpp::QoS& qos,
+            const rclcpp::PublisherOptionsBase& options);
 
   ~Publisher();
 

--- a/drake_ros_core/src/subscription.cc
+++ b/drake_ros_core/src/subscription.cc
@@ -34,22 +34,17 @@ Subscription::Subscription(
     rclcpp::node_interfaces::NodeBaseInterface* node_base,
     const rosidl_message_type_support_t& ts, const std::string& topic_name,
     const rclcpp::QoS& qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
-    const rclcpp::SubscriptionOptionsBase& options)
-#if RCLCPP_VERSION_GTE(18, 0, 0)
-    : rclcpp::SubscriptionBase(
-          node_base, ts, topic_name, subscription_options(qos),
-          options.event_callbacks, options.use_default_callbacks, true),
-      callback_(callback){}
-#else
+    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
     : rclcpp::SubscriptionBase(node_base, ts, topic_name,
-                               subscription_options(qos), true),
-      callback_(callback) {
-}
+                               subscription_options(qos),
+#if RCLCPP_VERSION_GTE(18, 0, 0)
+                               {}, true, true),
+#else
+                               true),
 #endif
+      callback_(callback) {}
 
-      Subscription::~Subscription() {
-}
+Subscription::~Subscription() {}
 
 std::shared_ptr<void> Subscription::create_message() {
   // Subscriber only does serialized messages

--- a/drake_ros_core/src/subscription.cc
+++ b/drake_ros_core/src/subscription.cc
@@ -36,17 +36,18 @@ Subscription::Subscription(
     const rclcpp::QoS& qos,
     std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
 #if RCLCPP_VERSION_GTE(18, 0, 0)
-    : rclcpp::SubscriptionBase(
-        node_base, ts, topic_name, subscription_options(qos),
-        /* event_callbacks */ {},
-        /* use_default_callbacks */ true,
-        /* is_serialized */ true),
+    : rclcpp::SubscriptionBase(node_base, ts, topic_name,
+                               subscription_options(qos),
+                               /* event_callbacks */ {},
+                               /* use_default_callbacks */ true,
+                               /* is_serialized */ true),
 #else
-    : rclcpp::SubscriptionBase(
-        node_base, ts, topic_name, subscription_options(qos),
-        /* is_serialized */ true),
+    : rclcpp::SubscriptionBase(node_base, ts, topic_name,
+                               subscription_options(qos),
+                               /* is_serialized */ true),
 #endif
-      callback_(callback) {}
+      callback_(callback) {
+}
 
 Subscription::~Subscription() {}
 

--- a/drake_ros_core/src/subscription.cc
+++ b/drake_ros_core/src/subscription.cc
@@ -42,7 +42,8 @@ Subscription::Subscription(
 #else
                                true),
 #endif
-      callback_(callback) {}
+      callback_(callback) {
+}
 
 Subscription::~Subscription() {}
 

--- a/drake_ros_core/src/subscription.cc
+++ b/drake_ros_core/src/subscription.cc
@@ -35,15 +35,18 @@ Subscription::Subscription(
     const rosidl_message_type_support_t& ts, const std::string& topic_name,
     const rclcpp::QoS& qos,
     std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
-    : rclcpp::SubscriptionBase(node_base, ts, topic_name,
-                               subscription_options(qos),
 #if RCLCPP_VERSION_GTE(18, 0, 0)
-                               {}, true, true),
+    : rclcpp::SubscriptionBase(
+        node_base, ts, topic_name, subscription_options(qos),
+        /* event_callbacks */ {},
+        /* use_default_callbacks */ true,
+        /* is_serialized */ true),
 #else
-                               true),
+    : rclcpp::SubscriptionBase(
+        node_base, ts, topic_name, subscription_options(qos),
+        /* is_serialized */ true),
 #endif
-      callback_(callback) {
-}
+      callback_(callback) {}
 
 Subscription::~Subscription() {}
 

--- a/drake_ros_core/src/subscription.cc
+++ b/drake_ros_core/src/subscription.cc
@@ -17,6 +17,8 @@
 #include <memory>
 #include <string>
 
+#include <rclcpp/version.h>
+
 namespace drake_ros_core {
 namespace internal {
 namespace {
@@ -32,12 +34,22 @@ Subscription::Subscription(
     rclcpp::node_interfaces::NodeBaseInterface* node_base,
     const rosidl_message_type_support_t& ts, const std::string& topic_name,
     const rclcpp::QoS& qos,
-    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+    std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
+    const rclcpp::SubscriptionOptionsBase& options)
+#if RCLCPP_VERSION_GTE(18, 0, 0)
+    : rclcpp::SubscriptionBase(
+          node_base, ts, topic_name, subscription_options(qos),
+          options.event_callbacks, options.use_default_callbacks, true),
+      callback_(callback){}
+#else
     : rclcpp::SubscriptionBase(node_base, ts, topic_name,
                                subscription_options(qos), true),
-      callback_(callback) {}
+      callback_(callback) {
+}
+#endif
 
-Subscription::~Subscription() {}
+      Subscription::~Subscription() {
+}
 
 std::shared_ptr<void> Subscription::create_message() {
   // Subscriber only does serialized messages

--- a/drake_ros_core/src/subscription.h
+++ b/drake_ros_core/src/subscription.h
@@ -16,8 +16,9 @@
 #include <memory>
 #include <string>
 
-#include "rclcpp/qos.hpp"
-#include "rclcpp/subscription_base.hpp"
+#include <rclcpp/qos.hpp>
+#include <rclcpp/subscription_base.hpp>
+#include <rclcpp/subscription_options.hpp>
 #include <rmw/serialized_message.h>
 #include <rosidl_runtime_c/message_type_support_struct.h>
 
@@ -31,7 +32,15 @@ class Subscription final : public rclcpp::SubscriptionBase {
       rclcpp::node_interfaces::NodeBaseInterface* node_base,
       const rosidl_message_type_support_t& ts, const std::string& topic_name,
       const rclcpp::QoS& qos,
-      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
+      : Subscription(node_base, ts, topic_name, qos, callback, {}) {}
+
+  Subscription(
+      rclcpp::node_interfaces::NodeBaseInterface* node_base,
+      const rosidl_message_type_support_t& ts, const std::string& topic_name,
+      const rclcpp::QoS& qos,
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
+      const rclcpp::SubscriptionOptionsBase& options);
 
   ~Subscription();
 

--- a/drake_ros_core/src/subscription.h
+++ b/drake_ros_core/src/subscription.h
@@ -18,7 +18,6 @@
 
 #include <rclcpp/qos.hpp>
 #include <rclcpp/subscription_base.hpp>
-#include <rclcpp/subscription_options.hpp>
 #include <rmw/serialized_message.h>
 #include <rosidl_runtime_c/message_type_support_struct.h>
 
@@ -32,15 +31,7 @@ class Subscription final : public rclcpp::SubscriptionBase {
       rclcpp::node_interfaces::NodeBaseInterface* node_base,
       const rosidl_message_type_support_t& ts, const std::string& topic_name,
       const rclcpp::QoS& qos,
-      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback)
-      : Subscription(node_base, ts, topic_name, qos, callback, {}) {}
-
-  Subscription(
-      rclcpp::node_interfaces::NodeBaseInterface* node_base,
-      const rosidl_message_type_support_t& ts, const std::string& topic_name,
-      const rclcpp::QoS& qos,
-      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback,
-      const rclcpp::SubscriptionOptionsBase& options);
+      std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback);
 
   ~Subscription();
 


### PR DESCRIPTION
APIs we're using changed in https://github.com/ros2/rclcpp/pull/2066 which is released in RCLCPP 18.0.0 in ROS ROlling. This PR uses the updated API.

Fixes #208

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/210)
<!-- Reviewable:end -->
