### PR TITLE
Strip "/" characters from workspace paths for ROS2

### DIFF
--- a/bazel_ros2_rules/ros2/defs.bzl
+++ b/bazel_ros2_rules/ros2/defs.bzl
@@ -222,6 +222,7 @@ def _ros2_local_repository_impl(repo_ctx):
     repo_ctx.report_progress("Sandboxing ROS 2 workspaces")
     workspaces_in_sandbox = {}
     for path in repo_ctx.attr.workspaces:
+        path = path.rstrip("/")
         path_in_sandbox = path.replace("/", "_")
         repo_ctx.symlink(path, path_in_sandbox)
         workspaces_in_sandbox[path] = path_in_sandbox


### PR DESCRIPTION
This PR addresses https://github.com/RobotLocomotion/drake-ros/issues/64 by stripping the trailing "/" characters from workspace strings.

Signed off by : aditya050995@gmail.com

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/211)
<!-- Reviewable:end -->
