### PR TITLE
Fix minor ros2bzl error message spelling mistake

### DIFF
--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/__init__.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/__init__.py
@@ -42,7 +42,7 @@ def build_dependency_graph(packages, include=None, exclude=None):
         include = set(include)
         if not package_set.issuperset(include):
             unknown_packages = tuple(include.difference(package_set))
-            msg = 'Cannont find package'
+            msg = 'Cannot find package'
             if len(unknown_packages) == 1:
                 msg +=  ' ' + repr(unknown_packages[0])
             else:


### PR DESCRIPTION
@EricCousineau-TRI Based on the slack conversation. The mistake can be seen in the error message shared in this StackOverflow post [here](https://stackoverflow.com/questions/75138403/pulling-ros2-packages-in-via-bazel-workspace-mech-in-drake-ros)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/213)
<!-- Reviewable:end -->
