### PR TITLE
drake_ros_*:: -> drake_ros::*::  namespace

### DIFF
--- a/drake_ros/core/drake_ros.cc
+++ b/drake_ros/core/drake_ros.cc
@@ -7,7 +7,8 @@
 #include <rclcpp/executors.hpp>
 #include <rclcpp/node.hpp>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 struct DrakeRos::Impl {
   rclcpp::Context::SharedPtr context;
   rclcpp::Node::UniquePtr node;
@@ -59,4 +60,5 @@ void init(int argc, const char** argv) {
 
 bool shutdown() { return rclcpp::shutdown(); }
 
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/drake_ros.h
+++ b/drake_ros/core/drake_ros.h
@@ -6,7 +6,8 @@
 #include <rclcpp/node.hpp>
 #include <rclcpp/node_options.hpp>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 
 /** A Drake ROS interface that wraps a live ROS node.
 
@@ -65,4 +66,5 @@ void init(int argc = 0, const char** argv = nullptr);
 */
 bool shutdown();
 
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/geometry_conversions.cc
+++ b/drake_ros/core/geometry_conversions.cc
@@ -1,6 +1,7 @@
 #include "drake_ros/core/geometry_conversions.h"
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 
 Eigen::Vector3d RosPointToVector3(const geometry_msgs::msg::Point& point) {
   return Eigen::Vector3d(point.x, point.y, point.z);
@@ -183,4 +184,5 @@ geometry_msgs::msg::Wrench SpatialForceToRosWrench(
   return result;
 }
 
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/geometry_conversions.h
+++ b/drake_ros/core/geometry_conversions.h
@@ -41,7 +41,8 @@ expressing it).
 #include <geometry_msgs/msg/twist.hpp>
 #include <geometry_msgs/msg/wrench.hpp>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 
 // Vector / Translation.
 
@@ -127,4 +128,5 @@ drake::multibody::SpatialForce<double> RosWrenchToSpatialForce(
 geometry_msgs::msg::Wrench SpatialForceToRosWrench(
     const drake::multibody::SpatialForce<double>& force);
 
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/publisher.cc
+++ b/drake_ros/core/publisher.cc
@@ -4,7 +4,8 @@
 
 #include <rclcpp/version.h>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 namespace internal {
 namespace {
 // Copied from rosbag2_transport rosbag2_get_publisher_options
@@ -45,4 +46,5 @@ void Publisher::publish(const rclcpp::SerializedMessage& serialized_msg) {
   }
 }
 }  // namespace internal
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/publisher.h
+++ b/drake_ros/core/publisher.h
@@ -8,7 +8,8 @@
 #include <rclcpp/serialized_message.hpp>
 #include <rosidl_runtime_c/message_type_support_struct.h>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 namespace internal {
 // A type-erased version of rclcpp:::Publisher<Message>.
 // This class conforms to the ROS 2 C++ style for consistency.
@@ -23,4 +24,5 @@ class Publisher final : public rclcpp::PublisherBase {
   void publish(const rclcpp::SerializedMessage& serialized_msg);
 };
 }  // namespace internal
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/ros_interface_system.cc
+++ b/drake_ros/core/ros_interface_system.cc
@@ -4,7 +4,8 @@
 #include <memory>
 #include <utility>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 struct RosInterfaceSystem::Impl {
   // Interface to ROS (through a node).
   std::unique_ptr<DrakeRos> ros;
@@ -32,4 +33,5 @@ void RosInterfaceSystem::DoCalcNextUpdateTime(
   // order of node spinning and message taking affects it?
   *time = std::numeric_limits<double>::infinity();
 }
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/ros_interface_system.h
+++ b/drake_ros/core/ros_interface_system.h
@@ -6,7 +6,8 @@
 
 #include "drake_ros/core/drake_ros.h"
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 /** A system that manages a Drake ROS interface. */
 class RosInterfaceSystem : public drake::systems::LeafSystem<double> {
  public:
@@ -27,4 +28,5 @@ class RosInterfaceSystem : public drake::systems::LeafSystem<double> {
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/ros_publisher_system.cc
+++ b/drake_ros/core/ros_publisher_system.cc
@@ -9,7 +9,8 @@
 
 #include "drake_ros/core/serializer_interface.h"
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 struct RosPublisherSystem::Impl {
   // Interface for message (de)serialization.
   std::unique_ptr<SerializerInterface> serializer;
@@ -89,4 +90,5 @@ drake::systems::EventStatus RosPublisherSystem::PublishInput(
   impl_->pub->publish(impl_->serializer->Serialize(input));
   return drake::systems::EventStatus::Succeeded();
 }
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/ros_publisher_system.h
+++ b/drake_ros/core/ros_publisher_system.h
@@ -13,7 +13,8 @@
 #include "drake_ros/core/serializer.h"
 #include "drake_ros/core/serializer_interface.h"
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 /** A system that can publish ROS messages.
  It accepts ROS messages on its sole input port and publishes them
  to a ROS topic.
@@ -83,4 +84,5 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/ros_subscriber_system.cc
+++ b/drake_ros/core/ros_subscriber_system.cc
@@ -8,7 +8,8 @@
 #include "subscription.h"  // NOLINT(build/include)
 #include <drake/systems/framework/abstract_values.h>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 namespace {
 // A synchronized queue of `MessageT` messages.
 template <typename MessageT>
@@ -110,4 +111,5 @@ void RosSubscriberSystem::DoCalcNextUpdateTime(
   uu_events.AddEvent(drake::systems::UnrestrictedUpdateEvent<double>(
       drake::systems::TriggerType::kTimed, callback));
 }
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/ros_subscriber_system.h
+++ b/drake_ros/core/ros_subscriber_system.h
@@ -11,7 +11,8 @@
 #include "drake_ros/core/serializer.h"
 #include "drake_ros/core/serializer_interface.h"
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 /** A system that can subscribe to ROS messages.
  It subscribes to a ROS topic and makes ROS messages available on
  its sole output port.
@@ -55,4 +56,5 @@ class RosSubscriberSystem : public drake::systems::LeafSystem<double> {
   struct Impl;
   std::unique_ptr<Impl> impl_;
 };
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/serializer.h
+++ b/drake_ros/core/serializer.h
@@ -9,7 +9,8 @@
 
 #include "drake_ros/core/serializer_interface.h"
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 /** A (de)serialization interface implementation that is
  bound to C++ ROS messages of `MessageT` type. */
 template <typename MessageT>
@@ -40,4 +41,5 @@ class Serializer : public SerializerInterface {
  private:
   rclcpp::Serialization<MessageT> protocol_;
 };
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/serializer_interface.h
+++ b/drake_ros/core/serializer_interface.h
@@ -6,7 +6,8 @@
 #include <rclcpp/serialized_message.hpp>
 #include <rosidl_typesupport_cpp/message_type_support.hpp>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 /** An interface for (de)serialization of a ROS message.
 
  This interface deals with ROS messages of a fixed message
@@ -42,4 +43,5 @@ class SerializerInterface {
   /** Returns a reference to the ROS message typesupport. */
   virtual const rosidl_message_type_support_t* GetTypeSupport() const = 0;
 };
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/subscription.cc
+++ b/drake_ros/core/subscription.cc
@@ -5,7 +5,8 @@
 
 #include <rclcpp/version.h>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 namespace internal {
 namespace {
 // Copied from rosbag2_transport rosbag2_get_subscription_options
@@ -80,4 +81,5 @@ void Subscription::return_serialized_message(
   message.reset();
 }
 }  // namespace internal
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/subscription.h
+++ b/drake_ros/core/subscription.h
@@ -8,7 +8,8 @@
 #include <rmw/serialized_message.h>
 #include <rosidl_runtime_c/message_type_support_struct.h>
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 namespace internal {
 // A type-erased version of rclcpp:::Subscription<Message>.
 // This class conforms to the ROS 2 C++ style for consistency.
@@ -60,4 +61,5 @@ class Subscription final : public rclcpp::SubscriptionBase {
   std::function<void(std::shared_ptr<rclcpp::SerializedMessage>)> callback_;
 };
 }  // namespace internal
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/test/test_drake_ros.cc
+++ b/drake_ros/core/test/test_drake_ros.cc
@@ -8,12 +8,12 @@
 
 #include "drake_ros/core/drake_ros.h"
 
-using drake_ros_core::DrakeRos;
+using drake_ros::core::DrakeRos;
 
 TEST(DrakeRos, default_construct) {
-  drake_ros_core::init();
+  drake_ros::core::init();
   EXPECT_NO_THROW(std::make_unique<DrakeRos>("default_node"));
-  EXPECT_TRUE(drake_ros_core::shutdown());
+  EXPECT_TRUE(drake_ros::core::shutdown());
 }
 
 TEST(DrakeRos, local_context) {

--- a/drake_ros/core/test/test_geometry_conversions.cc
+++ b/drake_ros/core/test/test_geometry_conversions.cc
@@ -2,7 +2,8 @@
 
 #include "drake_ros/core/geometry_conversions.h"
 
-namespace drake_ros_core {
+namespace drake_ros {
+namespace core {
 namespace {
 
 // N.B. For the purpose of testing type conversions, we should use explicit
@@ -312,4 +313,5 @@ TEST(GeometryConversions, Force) {
 }
 
 }  // namespace
-}  // namespace drake_ros_core
+}  // namespace core
+}  // namespace drake_ros

--- a/drake_ros/core/test/test_pub_sub.cc
+++ b/drake_ros/core/test/test_pub_sub.cc
@@ -13,13 +13,13 @@
 #include "drake_ros/core/ros_publisher_system.h"
 #include "drake_ros/core/ros_subscriber_system.h"
 
-using drake_ros_core::DrakeRos;
-using drake_ros_core::RosInterfaceSystem;
-using drake_ros_core::RosPublisherSystem;
-using drake_ros_core::RosSubscriberSystem;
+using drake_ros::core::DrakeRos;
+using drake_ros::core::RosInterfaceSystem;
+using drake_ros::core::RosPublisherSystem;
+using drake_ros::core::RosSubscriberSystem;
 
 TEST(Integration, sub_to_pub) {
-  drake_ros_core::init(0, nullptr);
+  drake_ros::core::init(0, nullptr);
 
   drake::systems::DiagramBuilder<double> builder;
 
@@ -90,7 +90,7 @@ TEST(Integration, sub_to_pub) {
     EXPECT_EQ(rx_msgs_direct_sub_out.back()->uint64_value, i);
   }
 
-  drake_ros_core::shutdown();
+  drake_ros::core::shutdown();
 }
 
 // Only available in Bazel.

--- a/drake_ros/drake_ros/core/cc_pybind.cc
+++ b/drake_ros/drake_ros/core/cc_pybind.cc
@@ -18,13 +18,13 @@
 namespace drake_ros {
 namespace drake_ros_py DRAKE_ROS_NO_EXPORT {
 
-using drake_ros_core::DrakeRos;
-using drake_ros_core::init;
-using drake_ros_core::RosInterfaceSystem;
-using drake_ros_core::RosPublisherSystem;
-using drake_ros_core::RosSubscriberSystem;
-using drake_ros_core::SerializerInterface;
-using drake_ros_core::shutdown;
+using drake_ros::core::DrakeRos;
+using drake_ros::core::init;
+using drake_ros::core::RosInterfaceSystem;
+using drake_ros::core::RosPublisherSystem;
+using drake_ros::core::RosSubscriberSystem;
+using drake_ros::core::SerializerInterface;
+using drake_ros::core::shutdown;
 
 using drake::systems::LeafSystem;
 using drake::systems::TriggerType;
@@ -164,71 +164,71 @@ void DefCore(py::module m) {
 
   // Python bindings for geometry conversions.
   // Vector / Translation functions.
-  m.def("RosPointToVector3", &drake_ros_core::RosPointToVector3,
+  m.def("RosPointToVector3", &drake_ros::core::RosPointToVector3,
         py::arg("point"));
-  m.def("Vector3ToRosPoint", &drake_ros_core::Vector3ToRosPoint,
+  m.def("Vector3ToRosPoint", &drake_ros::core::Vector3ToRosPoint,
         py::arg("point"));
-  m.def("RosVector3ToVector3", &drake_ros_core::RosVector3ToVector3,
+  m.def("RosVector3ToVector3", &drake_ros::core::RosVector3ToVector3,
         py::arg("point"));
-  m.def("Vector3ToRosVector3", &drake_ros_core::Vector3ToRosVector3,
+  m.def("Vector3ToRosVector3", &drake_ros::core::Vector3ToRosVector3,
         py::arg("point"));
 
   // Orientation
-  m.def("RosQuaternionToQuaternion", &drake_ros_core::RosQuaternionToQuaternion,
+  m.def("RosQuaternionToQuaternion", &drake_ros::core::RosQuaternionToQuaternion,
         py::arg("quat"));
-  m.def("QuaternionToRosQuaternion", &drake_ros_core::QuaternionToRosQuaternion,
+  m.def("QuaternionToRosQuaternion", &drake_ros::core::QuaternionToRosQuaternion,
         py::arg("quat"));
   m.def("RosQuaternionToRotationMatrix",
-        &drake_ros_core::RosQuaternionToRotationMatrix, py::arg("quat"));
+        &drake_ros::core::RosQuaternionToRotationMatrix, py::arg("quat"));
   m.def("RotationMatrixToRosQuaternion",
-        &drake_ros_core::RotationMatrixToRosQuaternion, py::arg("rotation"));
+        &drake_ros::core::RotationMatrixToRosQuaternion, py::arg("rotation"));
 
   // Pose
-  m.def("RosPoseToRigidTransform", &drake_ros_core::RosPoseToRigidTransform,
+  m.def("RosPoseToRigidTransform", &drake_ros::core::RosPoseToRigidTransform,
         py::arg("pose"));
-  m.def("RigidTransformToRosPose", &drake_ros_core::RigidTransformToRosPose,
+  m.def("RigidTransformToRosPose", &drake_ros::core::RigidTransformToRosPose,
         py::arg("transform"));
   m.def("RosTransformToRigidTransform",
-        &drake_ros_core::RosTransformToRigidTransform, py::arg("transform"));
+        &drake_ros::core::RosTransformToRigidTransform, py::arg("transform"));
   m.def("RigidTransformToRosTransform",
-        &drake_ros_core::RigidTransformToRosTransform, py::arg("transform"));
-  m.def("RosPoseToIsometry3", &drake_ros_core::RosPoseToIsometry3,
+        &drake_ros::core::RigidTransformToRosTransform, py::arg("transform"));
+  m.def("RosPoseToIsometry3", &drake_ros::core::RosPoseToIsometry3,
         py::arg("pose"));
-  m.def("Isometry3ToRosPose", &drake_ros_core::Isometry3ToRosPose,
+  m.def("Isometry3ToRosPose", &drake_ros::core::Isometry3ToRosPose,
         py::arg("isometry"));
-  m.def("RosTransformToIsometry3", &drake_ros_core::RosTransformToIsometry3,
+  m.def("RosTransformToIsometry3", &drake_ros::core::RosTransformToIsometry3,
         py::arg("transform"));
-  m.def("Isometry3ToRosTransform", &drake_ros_core::Isometry3ToRosTransform,
+  m.def("Isometry3ToRosTransform", &drake_ros::core::Isometry3ToRosTransform,
         py::arg("isometry"));
 
   // Spatial Velocity
-  m.def("RosTwistToVector6", &drake_ros_core::RosTwistToVector6,
+  m.def("RosTwistToVector6", &drake_ros::core::RosTwistToVector6,
         py::arg("twist"));
-  m.def("Vector6ToRosTwist", &drake_ros_core::Vector6ToRosTwist,
+  m.def("Vector6ToRosTwist", &drake_ros::core::Vector6ToRosTwist,
         py::arg("vector"));
-  m.def("RosTwistToSpatialVelocity", &drake_ros_core::RosTwistToSpatialVelocity,
+  m.def("RosTwistToSpatialVelocity", &drake_ros::core::RosTwistToSpatialVelocity,
         py::arg("twist"));
-  m.def("SpatialVelocityToRosTwist", &drake_ros_core::SpatialVelocityToRosTwist,
+  m.def("SpatialVelocityToRosTwist", &drake_ros::core::SpatialVelocityToRosTwist,
         py::arg("velocity"));
 
   // Spatial Acceleration
-  m.def("RosAccelToVector6", &drake_ros_core::RosAccelToVector6,
+  m.def("RosAccelToVector6", &drake_ros::core::RosAccelToVector6,
         py::arg("accel"));
-  m.def("Vector6ToRosAccel", &drake_ros_core::Vector6ToRosAccel,
+  m.def("Vector6ToRosAccel", &drake_ros::core::Vector6ToRosAccel,
         py::arg("vector"));
   m.def("RosAccelToSpatialAcceleration",
-        &drake_ros_core::RosAccelToSpatialAcceleration, py::arg("accel"));
+        &drake_ros::core::RosAccelToSpatialAcceleration, py::arg("accel"));
   m.def("SpatialAccelerationToRosAccel",
-        &drake_ros_core::SpatialAccelerationToRosAccel, py::arg("accel"));
+        &drake_ros::core::SpatialAccelerationToRosAccel, py::arg("accel"));
 
   // Spatial Force
-  m.def("RosWrenchToVector6", &drake_ros_core::RosWrenchToVector6,
+  m.def("RosWrenchToVector6", &drake_ros::core::RosWrenchToVector6,
         py::arg("wrench"));
-  m.def("Vector6ToRosWrench", &drake_ros_core::Vector6ToRosWrench,
+  m.def("Vector6ToRosWrench", &drake_ros::core::Vector6ToRosWrench,
         py::arg("vector"));
-  m.def("RosWrenchToSpatialForce", &drake_ros_core::RosWrenchToSpatialForce,
+  m.def("RosWrenchToSpatialForce", &drake_ros::core::RosWrenchToSpatialForce,
         py::arg("wrench"));
-  m.def("SpatialForceToRosWrench", &drake_ros_core::SpatialForceToRosWrench,
+  m.def("SpatialForceToRosWrench", &drake_ros::core::SpatialForceToRosWrench,
         py::arg("force"));
 }
 // clang-format off

--- a/drake_ros/drake_ros/core/cc_pybind.cc
+++ b/drake_ros/drake_ros/core/cc_pybind.cc
@@ -174,10 +174,10 @@ void DefCore(py::module m) {
         py::arg("point"));
 
   // Orientation
-  m.def("RosQuaternionToQuaternion", &drake_ros::core::RosQuaternionToQuaternion,
-        py::arg("quat"));
-  m.def("QuaternionToRosQuaternion", &drake_ros::core::QuaternionToRosQuaternion,
-        py::arg("quat"));
+  m.def("RosQuaternionToQuaternion",
+        &drake_ros::core::RosQuaternionToQuaternion, py::arg("quat"));
+  m.def("QuaternionToRosQuaternion",
+        &drake_ros::core::QuaternionToRosQuaternion, py::arg("quat"));
   m.def("RosQuaternionToRotationMatrix",
         &drake_ros::core::RosQuaternionToRotationMatrix, py::arg("quat"));
   m.def("RotationMatrixToRosQuaternion",
@@ -206,10 +206,10 @@ void DefCore(py::module m) {
         py::arg("twist"));
   m.def("Vector6ToRosTwist", &drake_ros::core::Vector6ToRosTwist,
         py::arg("vector"));
-  m.def("RosTwistToSpatialVelocity", &drake_ros::core::RosTwistToSpatialVelocity,
-        py::arg("twist"));
-  m.def("SpatialVelocityToRosTwist", &drake_ros::core::SpatialVelocityToRosTwist,
-        py::arg("velocity"));
+  m.def("RosTwistToSpatialVelocity",
+        &drake_ros::core::RosTwistToSpatialVelocity, py::arg("twist"));
+  m.def("SpatialVelocityToRosTwist",
+        &drake_ros::core::SpatialVelocityToRosTwist, py::arg("velocity"));
 
   // Spatial Acceleration
   m.def("RosAccelToVector6", &drake_ros::core::RosAccelToVector6,

--- a/drake_ros/drake_ros/tf2/cc_pybind.cc
+++ b/drake_ros/drake_ros/tf2/cc_pybind.cc
@@ -17,9 +17,9 @@ using drake::systems::TriggerType;
 void DefTf2(py::module m) {
   m.doc() = "Python wrapper for drake_ros.tf2";
 
-  using drake_ros_core::DrakeRos;
-  using drake_ros_tf2::SceneTfBroadcasterParams;
-  using drake_ros_tf2::SceneTfBroadcasterSystem;
+  using drake_ros::core::DrakeRos;
+  using drake_ros::tf2::SceneTfBroadcasterParams;
+  using drake_ros::tf2::SceneTfBroadcasterSystem;
 
   py::module::import("drake_ros.core");
 

--- a/drake_ros/drake_ros/viz/cc_pybind.cc
+++ b/drake_ros/drake_ros/viz/cc_pybind.cc
@@ -11,9 +11,9 @@
 namespace drake_ros {
 namespace drake_ros_py DRAKE_ROS_NO_EXPORT {
 
-using drake_ros_core::DrakeRos;
-using drake_ros_viz::RvizVisualizer;
-using drake_ros_viz::RvizVisualizerParams;
+using drake_ros::core::DrakeRos;
+using drake_ros::viz::RvizVisualizer;
+using drake_ros::viz::RvizVisualizerParams;
 
 using drake::systems::Diagram;
 using drake::systems::TriggerType;

--- a/drake_ros/tf2/internal_name_conventions.h
+++ b/drake_ros/tf2/internal_name_conventions.h
@@ -3,7 +3,8 @@
 #include <sstream>
 #include <string>
 
-namespace drake_ros_tf2 {
+namespace drake_ros {
+namespace tf2 {
 namespace internal {
 
 std::string ReplaceAllOccurrences(std::string string, const std::string& target,
@@ -60,4 +61,5 @@ std::string CalcTfFrameName(const std::string& frame_name,
 }
 
 }  // namespace internal
-}  // namespace drake_ros_tf2
+}  // namespace tf2
+}  // namespace drake_ros

--- a/drake_ros/tf2/name_conventions.cc
+++ b/drake_ros/tf2/name_conventions.cc
@@ -6,7 +6,8 @@
 
 #include "internal_name_conventions.h"  // NOLINT
 
-namespace drake_ros_tf2 {
+namespace drake_ros {
+namespace tf2 {
 
 std::string GetTfFrameName(
     const drake::multibody::Body<double>& body,
@@ -51,4 +52,5 @@ std::string GetTfFrameName(
   return GetTfFrameName(inspector, plants, inspector.GetFrameId(geometry_id));
 }
 
-}  // namespace drake_ros_tf2
+}  // namespace tf2
+}  // namespace drake_ros

--- a/drake_ros/tf2/name_conventions.h
+++ b/drake_ros/tf2/name_conventions.h
@@ -6,7 +6,8 @@
 #include <drake/geometry/scene_graph_inspector.h>
 #include <drake/multibody/plant/multibody_plant.h>
 
-namespace drake_ros_tf2 {
+namespace drake_ros {
+namespace tf2 {
 
 /** Retrieve conventional tf frame name for a given scene frame.
 
@@ -47,4 +48,5 @@ std::string GetTfFrameName(
     const drake::multibody::Body<double>& body,
     const drake::multibody::MultibodyPlant<double>* plant,
     const drake::geometry::FrameId& frame_id);
-}  // namespace drake_ros_tf2
+}  // namespace tf2
+}  // namespace drake_ros

--- a/drake_ros/tf2/scene_tf_broadcaster_system.cc
+++ b/drake_ros/tf2/scene_tf_broadcaster_system.cc
@@ -11,7 +11,8 @@
 
 #include "drake_ros/tf2/scene_tf_system.h"
 
-namespace drake_ros_tf2 {
+namespace drake_ros {
+namespace tf2 {
 
 class SceneTfBroadcasterSystem::Impl {
  public:
@@ -20,13 +21,13 @@ class SceneTfBroadcasterSystem::Impl {
 };
 
 SceneTfBroadcasterSystem::SceneTfBroadcasterSystem(
-    drake_ros_core::DrakeRos* ros, SceneTfBroadcasterParams params)
+    drake_ros::core::DrakeRos* ros, SceneTfBroadcasterParams params)
     : impl_(new Impl()) {
   drake::systems::DiagramBuilder<double> builder;
 
   impl_->scene_tf = builder.AddSystem<SceneTfSystem>();
 
-  using drake_ros_core::RosPublisherSystem;
+  using drake_ros::core::RosPublisherSystem;
   auto scene_tf_publisher =
       builder.AddSystem(RosPublisherSystem::Make<tf2_msgs::msg::TFMessage>(
           params.tf_topic_name, tf2_ros::DynamicBroadcasterQoS(), ros,
@@ -57,4 +58,5 @@ SceneTfBroadcasterSystem::get_graph_query_input_port() const {
   return get_input_port(impl_->graph_query_port_index);
 }
 
-}  // namespace drake_ros_tf2
+}  // namespace tf2
+}  // namespace drake_ros

--- a/drake_ros/tf2/scene_tf_broadcaster_system.h
+++ b/drake_ros/tf2/scene_tf_broadcaster_system.h
@@ -8,7 +8,8 @@
 #include <drake/systems/framework/leaf_system.h>
 #include <drake_ros/core/drake_ros.h>
 
-namespace drake_ros_tf2 {
+namespace drake_ros {
+namespace tf2 {
 
 /** Set of parameters that configure a SceneTfBroadcasterSystem. */
 struct SceneTfBroadcasterParams {
@@ -39,7 +40,7 @@ class SceneTfBroadcasterSystem : public drake::systems::Diagram<double> {
    @param[in] ros interface to a live ROS node to publish from.
    @param[in] params optional broadcasting configuration.
    */
-  explicit SceneTfBroadcasterSystem(drake_ros_core::DrakeRos* ros,
+  explicit SceneTfBroadcasterSystem(drake_ros::core::DrakeRos* ros,
                                     SceneTfBroadcasterParams params = {});
   ~SceneTfBroadcasterSystem() override;
 
@@ -57,4 +58,5 @@ class SceneTfBroadcasterSystem : public drake::systems::Diagram<double> {
 
   std::unique_ptr<Impl> impl_;
 };
-}  // namespace drake_ros_tf2
+}  // namespace tf2
+}  // namespace drake_ros

--- a/drake_ros/tf2/scene_tf_system.cc
+++ b/drake_ros/tf2/scene_tf_system.cc
@@ -12,9 +12,10 @@
 #include "drake_ros/core/geometry_conversions.h"
 #include "drake_ros/tf2/name_conventions.h"
 
-namespace drake_ros_tf2 {
+namespace drake_ros {
+namespace tf2 {
 
-using drake_ros_core::RigidTransformToRosTransform;
+using drake_ros::core::RigidTransformToRosTransform;
 
 class SceneTfSystem::Impl {
  public:
@@ -150,4 +151,5 @@ void SceneTfSystem::CalcSceneTf(const drake::systems::Context<double>& context,
   }
 }
 
-}  // namespace drake_ros_tf2
+}  // namespace tf2
+}  // namespace drake_ros

--- a/drake_ros/tf2/scene_tf_system.h
+++ b/drake_ros/tf2/scene_tf_system.h
@@ -7,7 +7,8 @@
 #include <drake/systems/framework/leaf_system.h>
 #include <tf2_msgs/msg/tf_message.hpp>
 
-namespace drake_ros_tf2 {
+namespace drake_ros {
+namespace tf2 {
 /** System for SceneGraph frame transforms aggregation as a ROS tf2 message.
 
  This system outputs a `tf2_msgs/msg/TFMessage` populated with the
@@ -62,4 +63,5 @@ class SceneTfSystem : public drake::systems::LeafSystem<double> {
 
   std::unique_ptr<Impl> impl_;
 };
-}  // namespace drake_ros_tf2
+}  // namespace tf2
+}  // namespace drake_ros

--- a/drake_ros/tf2/test/test_name_conventions.cc
+++ b/drake_ros/tf2/test/test_name_conventions.cc
@@ -13,56 +13,56 @@ using drake::systems::DiagramBuilder;
 TEST(NameConventions, CalcTfFrameNameWithBody) {
   // All names are present
   EXPECT_EQ("model_name/body_name/456",
-            drake_ros_tf2::internal::CalcTfFrameName<int>(
+            drake_ros::tf2::internal::CalcTfFrameName<int>(
                 "model_name", "body_name", 123, 456));
 
   // Scoped model name and body name
   EXPECT_EQ("model_scope/model_name/body_scope/body_name/456",
-            drake_ros_tf2::internal::CalcTfFrameName(
+            drake_ros::tf2::internal::CalcTfFrameName(
                 "model_scope::model_name", "body_scope::body_name", 123, 456));
 
   // Model name with empty body name
   EXPECT_EQ(
       "model_name/unnamed_body_123/456",
-      drake_ros_tf2::internal::CalcTfFrameName("model_name", "", 123, 456));
+      drake_ros::tf2::internal::CalcTfFrameName("model_name", "", 123, 456));
 
   // Scoped model name with empty body name
   EXPECT_EQ("model_scope/model_name/unnamed_body_123/456",
-            drake_ros_tf2::internal::CalcTfFrameName("model_scope::model_name",
+            drake_ros::tf2::internal::CalcTfFrameName("model_scope::model_name",
                                                      "", 123, 456));
 }
 
 TEST(NameConventions, CalcTfFrameNameWithoutBody) {
   // Frame name is not empty
   EXPECT_EQ("frame_name",
-            drake_ros_tf2::internal::CalcTfFrameName("frame_name", 123));
+            drake_ros::tf2::internal::CalcTfFrameName("frame_name", 123));
 
   // Frame name is empty
   EXPECT_EQ("unnamed_frame_123",
-            drake_ros_tf2::internal::CalcTfFrameName("", 123));
+            drake_ros::tf2::internal::CalcTfFrameName("", 123));
 
   // Frame name with / delimiters
   EXPECT_EQ("scope_one/scope_two/frame_name",
-            drake_ros_tf2::internal::CalcTfFrameName(
+            drake_ros::tf2::internal::CalcTfFrameName(
                 "scope_one/scope_two/frame_name", 123));
 
   // Frame name with :: delimiters
   EXPECT_EQ("scope_one/scope_two/frame_name",
-            drake_ros_tf2::internal::CalcTfFrameName(
+            drake_ros::tf2::internal::CalcTfFrameName(
                 "scope_one::scope_two::frame_name", 123));
 
   // Frame name with mixed delimiters
   EXPECT_EQ("scope_one/scope_two/frame_name",
-            drake_ros_tf2::internal::CalcTfFrameName(
+            drake_ros::tf2::internal::CalcTfFrameName(
                 "scope_one/scope_two::frame_name", 123));
 
   // Frame name with only :: delimiter
   EXPECT_EQ("unnamed_frame_123",
-            drake_ros_tf2::internal::CalcTfFrameName("::", 123));
+            drake_ros::tf2::internal::CalcTfFrameName("::", 123));
 
   // Frame name with only / delimiter
   EXPECT_EQ("unnamed_frame_123",
-            drake_ros_tf2::internal::CalcTfFrameName("/", 123));
+            drake_ros::tf2::internal::CalcTfFrameName("/", 123));
 }
 
 TEST(NameConventions, GetTfFrameNameWorld) {
@@ -78,6 +78,6 @@ TEST(NameConventions, GetTfFrameNameWorld) {
   FrameId frame_id = plant.GetBodyFrameIdOrThrow(
       plant.GetBodyIndices(world_model_index).at(0));
 
-  EXPECT_EQ("world", drake_ros_tf2::GetTfFrameName(
+  EXPECT_EQ("world", drake_ros::tf2::GetTfFrameName(
                          scene_graph.model_inspector(), plants, frame_id));
 }

--- a/drake_ros/tf2/test/test_name_conventions.cc
+++ b/drake_ros/tf2/test/test_name_conventions.cc
@@ -29,7 +29,7 @@ TEST(NameConventions, CalcTfFrameNameWithBody) {
   // Scoped model name with empty body name
   EXPECT_EQ("model_scope/model_name/unnamed_body_123/456",
             drake_ros::tf2::internal::CalcTfFrameName("model_scope::model_name",
-                                                     "", 123, 456));
+                                                      "", 123, 456));
 }
 
 TEST(NameConventions, CalcTfFrameNameWithoutBody) {

--- a/drake_ros/tf2/test/test_tf_broadcaster.cc
+++ b/drake_ros/tf2/test/test_tf_broadcaster.cc
@@ -22,13 +22,13 @@
 
 #include "drake_ros/tf2/scene_tf_broadcaster_system.h"
 
-using drake_ros_core::DrakeRos;
-using drake_ros_core::RosInterfaceSystem;
-using drake_ros_tf2::SceneTfBroadcasterParams;
-using drake_ros_tf2::SceneTfBroadcasterSystem;
+using drake_ros::core::DrakeRos;
+using drake_ros::core::RosInterfaceSystem;
+using drake_ros::tf2::SceneTfBroadcasterParams;
+using drake_ros::tf2::SceneTfBroadcasterSystem;
 
 TEST(SceneTfBroadcasting, NominalCase) {
-  drake_ros_core::init();
+  drake_ros::core::init();
 
   drake::systems::DiagramBuilder<double> builder;
 
@@ -121,7 +121,7 @@ TEST(SceneTfBroadcasting, NominalCase) {
   EXPECT_DOUBLE_EQ(odom_to_base_link.transform.rotation.z, R_OB.z());
   EXPECT_DOUBLE_EQ(odom_to_base_link.transform.rotation.w, R_OB.w());
 
-  EXPECT_TRUE(drake_ros_core::shutdown());
+  EXPECT_TRUE(drake_ros::core::shutdown());
 }
 
 // Only available in Bazel.

--- a/drake_ros/viz/internal_name_conventions.h
+++ b/drake_ros/viz/internal_name_conventions.h
@@ -6,7 +6,8 @@
 
 #include "drake_ros/viz/name_conventions.h"
 
-namespace drake_ros_viz {
+namespace drake_ros {
+namespace viz {
 namespace internal {
 
 std::string ReplaceAllOccurrences(std::string string, const std::string& target,
@@ -81,4 +82,5 @@ std::string CalcHierarchicalMarkerNamespace(
 }
 
 }  // namespace internal
-}  // namespace drake_ros_viz
+}  // namespace viz
+}  // namespace drake_ros

--- a/drake_ros/viz/name_conventions.cc
+++ b/drake_ros/viz/name_conventions.cc
@@ -6,7 +6,8 @@
 
 #include "internal_name_conventions.h"  // NOLINT
 
-namespace drake_ros_viz {
+namespace drake_ros {
+namespace viz {
 
 MarkerNamespaceFunction GetFlatMarkerNamespaceFunction(
     const std::optional<std::string>& marker_namespace_prefix) {
@@ -50,4 +51,5 @@ MarkerNamespaceFunction GetHierarchicalMarkerNamspaceFunction(
   };
 }
 
-}  // namespace drake_ros_viz
+}  // namespace viz
+}  // namespace drake_ros

--- a/drake_ros/viz/name_conventions.h
+++ b/drake_ros/viz/name_conventions.h
@@ -7,7 +7,8 @@
 #include <drake/geometry/scene_graph_inspector.h>
 #include <drake/multibody/plant/multibody_plant.h>
 
-namespace drake_ros_viz {
+namespace drake_ros {
+namespace viz {
 
 /** A functor that returns the marker namespace given information of a geometry.
   @param[in] inspector inspector for a given SceneGraph's data.
@@ -38,4 +39,5 @@ MarkerNamespaceFunction GetFlatMarkerNamespaceFunction(
 MarkerNamespaceFunction GetHierarchicalMarkerNamespaceFunction(
     const std::optional<std::string>& marker_namespace_prefix = std::nullopt);
 
-}  // namespace drake_ros_viz
+}  // namespace viz
+}  // namespace drake_ros

--- a/drake_ros/viz/rviz_visualizer.cc
+++ b/drake_ros/viz/rviz_visualizer.cc
@@ -13,21 +13,22 @@
 
 #include "drake_ros/viz/scene_markers_system.h"
 
-namespace drake_ros_viz {
+namespace drake_ros {
+namespace viz {
 
 class RvizVisualizer::RvizVisualizerPrivate {
  public:
   SceneMarkersSystem* scene_visual_markers;
   SceneMarkersSystem* scene_collision_markers;
-  drake_ros_tf2::SceneTfBroadcasterSystem* scene_tf_broadcaster{nullptr};
+  drake_ros::tf2::SceneTfBroadcasterSystem* scene_tf_broadcaster{nullptr};
 };
 
-RvizVisualizer::RvizVisualizer(drake_ros_core::DrakeRos* ros,
+RvizVisualizer::RvizVisualizer(drake_ros::core::DrakeRos* ros,
                                RvizVisualizerParams params)
     : impl_(new RvizVisualizerPrivate()) {
   drake::systems::DiagramBuilder<double> builder;
 
-  using drake_ros_core::RosPublisherSystem;
+  using drake_ros::core::RosPublisherSystem;
   auto scene_visual_markers_publisher = builder.AddSystem(
       RosPublisherSystem::Make<visualization_msgs::msg::MarkerArray>(
           "/scene_markers/visual", rclcpp::QoS(1), ros, params.publish_triggers,
@@ -59,8 +60,8 @@ RvizVisualizer::RvizVisualizer(drake_ros_core::DrakeRos* ros,
 
   if (params.publish_tf) {
     impl_->scene_tf_broadcaster =
-        builder.AddSystem<drake_ros_tf2::SceneTfBroadcasterSystem>(
-            ros, drake_ros_tf2::SceneTfBroadcasterParams{
+        builder.AddSystem<drake_ros::tf2::SceneTfBroadcasterSystem>(
+            ros, drake_ros::tf2::SceneTfBroadcasterParams{
                      params.publish_triggers, params.publish_period});
 
     builder.ConnectInput(
@@ -93,4 +94,5 @@ RvizVisualizer::get_graph_query_input_port() const {
   return get_input_port();
 }
 
-}  // namespace drake_ros_viz
+}  // namespace viz
+}  // namespace drake_ros

--- a/drake_ros/viz/rviz_visualizer.h
+++ b/drake_ros/viz/rviz_visualizer.h
@@ -7,7 +7,8 @@
 #include <drake/systems/framework/diagram.h>
 #include <drake_ros/core/drake_ros.h>
 
-namespace drake_ros_viz {
+namespace drake_ros {
+namespace viz {
 
 /// Set of parameters that configure an RvizVisualizer.
 struct RvizVisualizerParams {
@@ -41,7 +42,7 @@ class RvizVisualizer : public drake::systems::Diagram<double> {
     @param[in] ros interface to a live ROS node to publish from.
     @param[in] params optional rviz visualizer configurations.
     */
-  explicit RvizVisualizer(drake_ros_core::DrakeRos* ros,
+  explicit RvizVisualizer(drake_ros::core::DrakeRos* ros,
                           RvizVisualizerParams params = {});
 
   ~RvizVisualizer() override;
@@ -61,4 +62,5 @@ class RvizVisualizer : public drake::systems::Diagram<double> {
   std::unique_ptr<RvizVisualizerPrivate> impl_;
 };
 
-}  // namespace drake_ros_viz
+}  // namespace viz
+}  // namespace drake_ros

--- a/drake_ros/viz/scene_markers_system.cc
+++ b/drake_ros/viz/scene_markers_system.cc
@@ -24,9 +24,10 @@
 #include "drake_ros/tf2/name_conventions.h"
 #include "drake_ros/viz/name_conventions.h"
 
-namespace drake_ros_viz {
+namespace drake_ros {
+namespace viz {
 
-using drake_ros_core::RigidTransformToRosPose;
+using drake_ros::core::RigidTransformToRosPose;
 
 namespace {
 
@@ -64,7 +65,7 @@ class SceneGeometryToMarkers : public drake::geometry::ShapeReifier {
     marker_array_ = marker_array;
 
     prototype_marker_.header.frame_id =
-        drake_ros_tf2::GetTfFrameName(inspector, plants, geometry_id);
+        drake_ros::tf2::GetTfFrameName(inspector, plants, geometry_id);
     prototype_marker_.ns = marker_namespace;
     prototype_marker_.id = marker_id;
     prototype_marker_.action = visualization_msgs::msg::Marker::MODIFY;
@@ -393,4 +394,5 @@ SceneMarkersSystem::get_markers_output_port() const {
   return get_output_port(impl_->scene_markers_port_index);
 }
 
-}  // namespace drake_ros_viz
+}  // namespace viz
+}  // namespace drake_ros

--- a/drake_ros/viz/scene_markers_system.h
+++ b/drake_ros/viz/scene_markers_system.h
@@ -11,7 +11,8 @@
 #include <drake_ros/viz/name_conventions.h>
 #include <visualization_msgs/msg/marker_array.hpp>
 
-namespace drake_ros_viz {
+namespace drake_ros {
+namespace viz {
 
 /// Set of parameters that configure a SceneMarkersSystem.
 struct SceneMarkersParams {
@@ -100,4 +101,5 @@ class SceneMarkersSystem : public drake::systems::LeafSystem<double> {
   std::unique_ptr<SceneMarkersSystemPrivate> impl_;
 };
 
-}  // namespace drake_ros_viz
+}  // namespace viz
+}  // namespace drake_ros

--- a/drake_ros/viz/test/test_name_conventions.cc
+++ b/drake_ros/viz/test/test_name_conventions.cc
@@ -5,64 +5,64 @@
 
 TEST(NameConventions, CalcMarkerNamespace) {
   EXPECT_EQ("prefix_geometry_owning_source_name",
-            drake_ros_viz::internal::CalcMarkerNamespace(
+            drake_ros::viz::internal::CalcMarkerNamespace(
                 "prefix_", "geometry_owning_source_name"));
 
   EXPECT_EQ("geometry_owning_source_name",
-            drake_ros_viz::internal::CalcMarkerNamespace(
+            drake_ros::viz::internal::CalcMarkerNamespace(
                 "", "geometry_owning_source_name"));
 
   EXPECT_EQ("prefix/model/geometry_owning_source_name",
-            drake_ros_viz::internal::CalcMarkerNamespace(
+            drake_ros::viz::internal::CalcMarkerNamespace(
                 "prefix/", "model::geometry_owning_source_name"));
 }
 
 TEST(NameConventions, CalcHierarchicalMarkerNamespaceWithBody) {
   // All names are present
   EXPECT_EQ("prefix/model_name/body_name/geometry_name",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "prefix/", "model_name", "body_name", "geometry_name"));
 
   // Scoped model name and body name
   EXPECT_EQ("prefix/model_scope/model_name/body_scope/body_name/geometry_name",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "prefix/", "model_scope::model_name", "body_scope::body_name",
                 "geometry_name"));
 
   // Model name with empty body name
   EXPECT_EQ("model_name/unnamed_body/geometry_name",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "", "model_name", "", "geometry_name"));
 
   // Scoped model name with empty body name and empty geometry name
   EXPECT_EQ("model_scope/model_name/unnamed_body/unnamed_geometry",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "", "model_scope::model_name", "", ""));
 }
 
 TEST(NameConventions, CalcHierarchicalMarkerNamespaceWithoutBody) {
   // Geometry source and name is not empty
   EXPECT_EQ("prefix/geometry_source/geometry_name",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "prefix/", "geometry_source", "geometry_name"));
 
   // Geometry name is empty
   EXPECT_EQ("prefix/geometry_source/unnamed_geometry",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "prefix/", "geometry_source", ""));
 
   // Geometry name with / delimiters
   EXPECT_EQ("geometry_source/scope_one/scope_two/geometry_name",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "", "geometry_source", "scope_one/scope_two/geometry_name"));
 
   // Geometry name with :: delimiters
   EXPECT_EQ("geometry_source/scope_one/scope_two/geometry_name",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "", "geometry_source", "scope_one::scope_two::geometry_name"));
 
   // Geometry name with mixed delimiters
   EXPECT_EQ("geometry_source/scope_one/scope_two/geometry_name",
-            drake_ros_viz::internal::CalcHierarchicalMarkerNamespace(
+            drake_ros::viz::internal::CalcHierarchicalMarkerNamespace(
                 "", "geometry_source", "scope_one/scope_two::geometry_name"));
 }

--- a/drake_ros/viz/test/test_scene_markers.cc
+++ b/drake_ros/viz/test/test_scene_markers.cc
@@ -15,7 +15,7 @@
 
 #include "drake_ros/viz/scene_markers_system.h"
 
-using drake_ros_viz::SceneMarkersSystem;
+using drake_ros::viz::SceneMarkersSystem;
 
 static constexpr char kSourceName[] = "test";
 static constexpr double kTolerance{1e-6};

--- a/drake_ros_examples/examples/iiwa_manipulator/iiwa_manipulator.cpp
+++ b/drake_ros_examples/examples/iiwa_manipulator/iiwa_manipulator.cpp
@@ -17,9 +17,9 @@
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "How many seconds to run the simulation");
 
-using drake_ros_core::DrakeRos;
-using drake_ros_core::RosInterfaceSystem;
-using drake_ros_viz::RvizVisualizer;
+using drake_ros::core::DrakeRos;
+using drake_ros::core::RosInterfaceSystem;
+using drake_ros::viz::RvizVisualizer;
 
 using drake::examples::manipulation_station::ManipulationStation;
 using drake::systems::Adder;
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
   gflags::ParseCommandLineFlags(&argc, &argv, false);
   drake::systems::DiagramBuilder<double> builder;
 
-  drake_ros_core::init();
+  drake_ros::core::init();
   auto ros_interface_system = builder.AddSystem<RosInterfaceSystem>(
       std::make_unique<DrakeRos>("iiwa_manipulator_node"));
 

--- a/drake_ros_examples/examples/multirobot/multirobot.cc
+++ b/drake_ros_examples/examples/multirobot/multirobot.cc
@@ -19,8 +19,8 @@
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "How many seconds to run the simulation");
 
-using drake_ros_core::DrakeRos;
-using drake_ros_core::RosInterfaceSystem;
+using drake_ros::core::DrakeRos;
+using drake_ros::core::RosInterfaceSystem;
 
 using drake::systems::ConstantVectorSource;
 using drake::systems::Simulator;
@@ -32,7 +32,7 @@ int main(int argc, char** argv) {
   drake::systems::DiagramBuilder<double> builder;
 
   // Initilise the ROS infrastructure
-  drake_ros_core::init();
+  drake_ros::core::init();
   // Create a Drake system to interface with ROS
   auto ros_interface_system = builder.AddSystem<RosInterfaceSystem>(
       std::make_unique<DrakeRos>("multirobot_node"));
@@ -47,17 +47,17 @@ int main(int argc, char** argv) {
   const double viz_dt = 1 / 32.0;
   // Add a TF2 broadcaster to provide task frame information
   auto scene_tf_broadcaster =
-      builder.AddSystem<drake_ros_tf2::SceneTfBroadcasterSystem>(
+      builder.AddSystem<drake_ros::tf2::SceneTfBroadcasterSystem>(
           ros_interface_system->get_ros_interface(),
-          drake_ros_tf2::SceneTfBroadcasterParams{
+          drake_ros::tf2::SceneTfBroadcasterParams{
               {TriggerType::kPeriodic}, viz_dt, "/tf"});
   builder.Connect(scene_graph.get_query_output_port(),
                   scene_tf_broadcaster->get_graph_query_input_port());
 
   // Add a system to output the visualisation markers for rviz
-  auto scene_visualizer = builder.AddSystem<drake_ros_viz::RvizVisualizer>(
+  auto scene_visualizer = builder.AddSystem<drake_ros::viz::RvizVisualizer>(
       ros_interface_system->get_ros_interface(),
-      drake_ros_viz::RvizVisualizerParams{
+      drake_ros::viz::RvizVisualizerParams{
           {TriggerType::kPeriodic}, viz_dt, true});
   builder.Connect(scene_graph.get_query_output_port(),
                   scene_visualizer->get_graph_query_input_port());

--- a/drake_ros_examples/examples/rs_flip_flop/rs_flip_flop.cpp
+++ b/drake_ros_examples/examples/rs_flip_flop/rs_flip_flop.cpp
@@ -15,10 +15,10 @@
 DEFINE_double(simulation_sec, std::numeric_limits<double>::infinity(),
               "How many seconds to run the simulation");
 
-using drake_ros_core::DrakeRos;
-using drake_ros_core::RosInterfaceSystem;
-using drake_ros_core::RosPublisherSystem;
-using drake_ros_core::RosSubscriberSystem;
+using drake_ros::core::DrakeRos;
+using drake_ros::core::RosInterfaceSystem;
+using drake_ros::core::RosPublisherSystem;
+using drake_ros::core::RosSubscriberSystem;
 
 class NorGate : public drake::systems::LeafSystem<double> {
  public:
@@ -95,7 +95,7 @@ int main(int argc, char** argv) {
 
   rclcpp::QoS qos{10};
 
-  drake_ros_core::init();
+  drake_ros::core::init();
   auto sys_ros_interface = builder.AddSystem<RosInterfaceSystem>(
       std::make_unique<DrakeRos>("rs_flip_flop_node"));
   auto sys_pub_Q =


### PR DESCRIPTION
fixes https://github.com/RobotLocomotion/drake-ros/issues/240

This was made by running commands like

```bash
# Split start of namespace
find . -name "*.cpp" -o -name "*.cc" -o -name "*.h" -o -name "*.hpp" | xargs sed -i 's+namespace drake_ros_core {+namespace drake_ros {\nnamespace core {+'

# Split end of namespace
find . -name "*.cpp" -o -name "*.cc" -o -name "*.h" -o -name "*.hpp" | xargs sed -i 's+}  // namespace drake_ros_viz+}  // namespace viz\n}  // namespace drake_ros+'

# Split use of namespace
find . -name "*.cpp" -o -name "*.cc" -o -name "*.h" -o -name "*.hpp" | xargs sed -i s/drake_ros_viz::/drake_ros::viz::/g
```

And to my surprise, `bazel build //...` and `bazel test //...` worked first try. The linters are run via CMake though, so opening PR to check those via CI.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/258)
<!-- Reviewable:end -->
