### PR TITLE
Add helper script to run all tests locally

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,8 @@ guide](https://drake.mit.edu/code_style_guide.html).
 
 For an example of using `colcon`, please see `../drake_ros_examples`.
 
+To build and run all tests, use `./run_all_tests.sh`.
+
 ## Continuous Integration
 
 This repository uses GitHub Actions to perform CI.

--- a/run_all_tests.sh
+++ b/run_all_tests.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+# Run all tests in this repository, intended to help local developers test
+# their changes prior to pushing to GitHub.
+
+# TODO(jwnimmer-tri) This does not yet run colcon-based tests.
+# TODO(jwnimmer-tri) This is missing fix_ament_lint. Running that script
+# currently requires extra setup steps ("ament_clang_format: No such ...").
+echo "NOTE: The aspirational goal of this script is to run all tests," \
+     "but at the moment it does NOT run any colcon-based tests."
+
+me=$(python3 -c 'import os; print(os.path.realpath("'"$0"'"))')
+cd $(dirname "$me")
+
+set -x
+(./fix_bazel_lint.sh --test ) && \
+(cd bazel_ros2_rules             && bazel build //...) && \
+(cd drake_ros                    && bazel test //...) && \
+(cd drake_ros_examples           && bazel test //...) && \
+(cd ros2_example_bazel_installed && bazel test //... @ros2//...) && \
+(cd ros2_example_bazel_installed && ./setup/runfiles_direct_test.sh) && \
+true


### PR DESCRIPTION
For at least the nominal settings of build options, CI should be a double-check, not a first-check; local testing should be trivial one-liner for contributors; and we should expect everyone to run the test suite locally before pushing to CI.

(To be clear -- using CI for canary builds like #245 is fine; the nominal build should be easy -- non-default options is OK to be more work.)

This is a first step towards enabling developers to quickly test their changes locally with confidence.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/262)
<!-- Reviewable:end -->
