### PR TITLE
Add C++ namespace alises to smooth the transition

### DIFF
--- a/drake_ros/core/drake_ros.h
+++ b/drake_ros/core/drake_ros.h
@@ -68,3 +68,6 @@ bool shutdown();
 
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/core/geometry_conversions.h
+++ b/drake_ros/core/geometry_conversions.h
@@ -130,3 +130,6 @@ geometry_msgs::msg::Wrench SpatialForceToRosWrench(
 
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/core/publisher.h
+++ b/drake_ros/core/publisher.h
@@ -26,3 +26,6 @@ class Publisher final : public rclcpp::PublisherBase {
 }  // namespace internal
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/core/ros_interface_system.h
+++ b/drake_ros/core/ros_interface_system.h
@@ -30,3 +30,6 @@ class RosInterfaceSystem : public drake::systems::LeafSystem<double> {
 };
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/core/ros_publisher_system.h
+++ b/drake_ros/core/ros_publisher_system.h
@@ -86,3 +86,6 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
 };
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/core/ros_subscriber_system.h
+++ b/drake_ros/core/ros_subscriber_system.h
@@ -58,3 +58,6 @@ class RosSubscriberSystem : public drake::systems::LeafSystem<double> {
 };
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/core/serializer_interface.h
+++ b/drake_ros/core/serializer_interface.h
@@ -45,3 +45,6 @@ class SerializerInterface {
 };
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/core/subscription.h
+++ b/drake_ros/core/subscription.h
@@ -63,3 +63,6 @@ class Subscription final : public rclcpp::SubscriptionBase {
 }  // namespace internal
 }  // namespace core
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_core = drake_ros::core;

--- a/drake_ros/tf2/name_conventions.h
+++ b/drake_ros/tf2/name_conventions.h
@@ -50,3 +50,6 @@ std::string GetTfFrameName(
     const drake::geometry::FrameId& frame_id);
 }  // namespace tf2
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_tf2 = drake_ros::tf2;

--- a/drake_ros/tf2/scene_tf_broadcaster_system.h
+++ b/drake_ros/tf2/scene_tf_broadcaster_system.h
@@ -60,3 +60,6 @@ class SceneTfBroadcasterSystem : public drake::systems::Diagram<double> {
 };
 }  // namespace tf2
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_tf2 = drake_ros::tf2;

--- a/drake_ros/tf2/scene_tf_system.h
+++ b/drake_ros/tf2/scene_tf_system.h
@@ -65,3 +65,6 @@ class SceneTfSystem : public drake::systems::LeafSystem<double> {
 };
 }  // namespace tf2
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_tf2 = drake_ros::tf2;

--- a/drake_ros/viz/name_conventions.h
+++ b/drake_ros/viz/name_conventions.h
@@ -41,3 +41,6 @@ MarkerNamespaceFunction GetHierarchicalMarkerNamespaceFunction(
 
 }  // namespace viz
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_viz = drake_ros::viz;

--- a/drake_ros/viz/rviz_visualizer.h
+++ b/drake_ros/viz/rviz_visualizer.h
@@ -64,3 +64,6 @@ class RvizVisualizer : public drake::systems::Diagram<double> {
 
 }  // namespace viz
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_viz = drake_ros::viz;

--- a/drake_ros/viz/scene_markers_system.h
+++ b/drake_ros/viz/scene_markers_system.h
@@ -103,3 +103,6 @@ class SceneMarkersSystem : public drake::systems::LeafSystem<double> {
 
 }  // namespace viz
 }  // namespace drake_ros
+
+// Legacy spelling for backwards compatibility.
+namespace drake_ros_viz = drake_ros::viz;


### PR DESCRIPTION
I've tested this locally using this patch to Anzu, to prove that is fixes the build for me:

```patch
diff --git a/tools/workspace/ros2/drake_ros_repository.bzl b/tools/workspace/ros2/drake_ros_repository.bzl
index 8af666988..391e31116 100644
--- a/tools/workspace/ros2/drake_ros_repository.bzl
+++ b/tools/workspace/ros2/drake_ros_repository.bzl
@@ -18,6 +18,7 @@
 def drake_ros_repository(name, mirrors = None):
     github_archive(
         name = name,
+        local_repository_override = "/home/jwnimmer/jwnimmer-tri/drake-ros",
         repository = "RobotLocomotion/drake-ros",
         extra_strip_prefix = "drake_ros",
         commit = COMMIT,

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/263)
<!-- Reviewable:end -->
