### PR TITLE
Docker Containerization  

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,70 @@
+# Dockerfile for drake-ros
+
+ARG ARCH
+FROM ${ARCH}/ros:humble
+
+# Set shell for running commands
+SHELL ["/bin/bash", "-c"]
+
+# Update package list, install necessary dependencies and cleanup package list 
+RUN apt-get update && \
+    apt-get install -y wget unzip curl software-properties-common lsb-release python3-pip && \
+    apt-get install qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools -y && \
+    apt-get install -y tzdata && \
+    rm -rf /var/lib/apt/lists/*
+
+# Install Bazel for arm64 systems since install_prereqs.sh doesn't for non x86_64 systems
+RUN case "${ARCH}" in arm64*) \
+    wget "https://github.com/bazelbuild/bazel/releases/download/6.2.0/bazel-6.2.0-linux-arm64" && \
+    chmod 755 bazel-6.2.0-linux-arm64 && \
+    mv bazel-6.2.0-linux-arm64 /usr/bin/bazel ;; \
+esac
+
+# Argument to support building Drake from source (only strictly necessary for ARM64 users)
+ARG BUILD_DRAKE_FROM_SOURCE=false 
+
+# Install Drake from source or download pre-built binary accordingly
+RUN if [ "$BUILD_DRAKE_FROM_SOURCE" = "true" ]; then \
+        # Install build dependencies for Drake \
+        apt-get update && \
+        apt-get install -y build-essential cmake && \
+        git clone https://github.com/RobotLocomotion/drake.git && \
+        yes | bash drake/setup/ubuntu/install_prereqs.sh && \
+        mkdir drake-build && \
+        cd drake-build && \
+        # Build Drake from source \
+        cmake -DCMAKE_INSTALL_PREFIX=/opt/drake ../drake && make -j$(nproc) && \
+        make install \
+    ; else \
+        # Update and add necessary keys and sources for Drake installation
+        apt-get update && apt-get install --no-install-recommends \
+        ca-certificates gnupg lsb-release wget && \
+        wget -qO- https://drake-apt.csail.mit.edu/drake.asc | gpg --dearmor - \
+        | tee /etc/apt/trusted.gpg.d/drake.gpg >/dev/null && \
+        echo "deb [arch=amd64] https://drake-apt.csail.mit.edu/$(lsb_release -cs) $(lsb_release -cs) main" \
+        | tee /etc/apt/sources.list.d/drake.list >/dev/null && \
+        apt-get update && apt-get install -y --no-install-recommends drake-dev && \
+        # Add Drake to the path 
+        echo 'export PATH="/opt/drake/bin${PATH:+:${PATH}}"' >> /etc/bash.bashrc && \
+        echo 'export PYTHONPATH="/opt/drake/lib/python'$(python3 -c 'import sys; print("{0}.{1}".format(*sys.version_info))')'/site-packages${PYTHONPATH:+:${PYTHONPATH}}"' >> /etc/bash.bashrc \
+    ; fi
+
+# Clone Drake ROS repository
+RUN git clone https://github.com/RobotLocomotion/drake-ros.git
+RUN cd drake-ros
+
+# ROS2 workspace setup
+RUN mkdir -p drake_ros_ws/src/drake_ros
+COPY . /drake_ros_ws/src/drake_ros
+
+RUN source /opt/ros/humble/setup.bash && \
+    cd drake_ros_ws/ && \
+    apt-get update --fix-missing && \
+    rosdep install -i --from-path src --rosdistro humble -y && \
+    colcon build --symlink-install && \
+    colcon test --packages-up-to drake_ros_examples --event-handlers console_cohesion+ && \
+    colcon test-result --verbose
+
+WORKDIR '/drake_ros_ws'
+# Set the entrypoint to source ROS setup.bash and run a bash shell
+ENTRYPOINT ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -30,8 +30,12 @@ capability:
 
   - Ubuntu 22.04 + ROS 2 Humble (Recommended)
   - Ubuntu 20.04 + ROS 2 Rolling
-  - Architecture: x86_64 (amd64)
+  - Mac (only via [Docker](./docker-README.md))
+  - Architecture: x86_64 (amd64), arm64 (only via [Docker](./docker-README.md))
   - Bazel >= 5.0
+
+## Docker Support
+For users preferring Docker, we offer support for Ubuntu and Macs via Docker. You can build and interact with visualization (`rviz2`) directly on the Docker platform, which is particularly useful for Mac users, including those with Apple Silicon architecture. Please refer to our detailed Docker instructions in the [Docker README](./docker-README.md).
 
 ## Usable! But No Stability Commitment
 

--- a/docker-README.md
+++ b/docker-README.md
@@ -1,0 +1,45 @@
+# drake-ros Docker README
+
+This is a README for using `drake-ros` with docker. It supports the following platforms - 
+  - Ubuntu 22.04 both `amd64` and `arm64`
+  - Apple Silicon Macs: Via `BUILD_DRAKE_FROM_SOURCE`
+The docker container would allow you to both visualize in `rviz2` (on M1 Macs as well via [noVNC](https://novnc.com/info.html)!) and develop.
+
+## **Prerequisites:**
+- Docker must be installed on your system. If you don't have Docker installed, follow the installation instructions at [https://docs.docker.com/engine/install/](https://docs.docker.com/engine/install/).
+- For NVIDIA GPU support, you need to have NVIDIA Container Toolkit installed. Follow the instructions at [https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) to install it.
+
+  - Rocker: `rocker` installation is required for NVIDIA GPU support. A simple way to install it is - `pip3 install rocker` Find out more about it [here](https://github.com/osrf/rocker).
+  - `nvidia-docker2`: Installation Instructions [here](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/user-guide.html#id2) 
+  
+
+## Instructions:
+1. Clone the repo and go to the directory containing the Dockerfile.
+2. Build the Docker image by running either -
+    ```
+    docker build --build-arg ARCH=arm64v8/ --build-arg BUILD_DRAKE_FROM_SOURCE=true -t drake-ros:arm64 .
+    (On arm64 systems, support is only available via building the source code.)
+    
+    docker build --build-arg ARCH=amd64/ --build-arg BUILD_DRAKE_FROM_SOURCE=false -t drake-ros:x86_64 .
+    (Recommended for x86 systems since it's significantly faster unless you want to build the latest drake)
+    ```
+
+**NOTE**: When building `drake` from source make sure you are alotting at least 8 gigs of RAM and limiting the number of cores (rule of thumb is 1 job per 8GB RAM) accordingly to the docker container as well. Otherwise, your builds will fail. 
+
+## Machines with Nvidia GPUs - 
+
+1. Start a Docker container with the `drake-ros` image using `rocker`. The following command mounts the current working directory (the root of the `drake-ros` repository) inside the container at `/drake_ros_ws/src/`, enables NVIDIA GPU support, and sets up X11 forwarding:
+
+    ```$ rocker --nvidia --x11 --volume "$(pwd):/drake_ros_ws/src/" -- drake-ros```
+
+  If needed, replace `drake-ros` with the name of the Docker image you built earlier.
+Alternatively, you can also run an equivalent `docker run` command.  
+
+## Machines without NVIDIA GPUs (Integrated CPU graphics, Apple Silicon etc.) -
+
+1. Use the provided docker compose via - `DRAKE_ROS_CONTAINER_NAME=my_custom_container_name docker compose up`
+2. In a new terminal, run the following to get a bash session running in the
+`drake-ros` container - `docker exec -it drake_ros_integration /bin/bash`
+3. Go to `http://localhost:8080/vnc.html` to see any visualizations that you may run. Example - `rviz2`
+
+Note - Since your drake-ros directory is mounted to the overlay ROS2 workspace in the container, any changes you make internally will be reflected on your host system. This is done to make development easier. You can read more about it [here](https://docs.docker.com/storage/volumes/). 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,44 @@
+# docker-compose.yml
+# 
+# NOTE - Only necessary for machines without an Nvidia GPU
+# This Docker Compose configuration sets up a Drake ROS integration environment
+# along with a noVNC server for remote access to the graphical interface of any
+# visualization tools used in the project.
+#
+# Author: Adeeb Abbas
+
+version: '3.8'
+services:
+  drake_ros:
+    container_name: ${DRAKE_ROS_CONTAINER_NAME}
+    # Use the drake-ros image for the simulation environment
+    # This image contains the necessary dependencies and configurations for running Drake ROS integration projects
+    image: drake-ros
+    build: ./
+    volumes: 
+      # Mount the current working directory (drake-ros repository) inside the container
+      # This allows for seamless synchronization between the host and container filesystems, ensuring that changes made in the host are reflected within the container
+      - .:/drake_ros_ws/src/drake_ros
+    environment:
+      # Configure the display environment variable for noVNC compatibility
+      # This ensures that graphical applications within the container can be accessed remotely via the noVNC server
+      - DISPLAY=novnc:0.0
+    networks:
+      - x11
+    stdin_open: true
+    tty: true
+  novnc:
+    container_name: novnc_container
+    image: theasp/novnc:latest
+    environment:
+      # Set the desired display resolution for the noVNC server
+      - DISPLAY_WIDTH=1728
+      - DISPLAY_HEIGHT=972
+    ports:
+      # Expose the noVNC server on port 8080 of the host system
+      - "8080:8080"
+    networks:
+      - x11
+    restart: on-failure
+networks:
+  x11: 


### PR DESCRIPTION
Targets #9

Ultimate aim is to be able to make `drake-ros` be accessible to all commonly used platforms for anyone to develop and try stuff out! 

Some notes about the approach, might be useful for the reviewers -
~- I use `npm` to install bazelisk as Drake's prereq installer doesn't yet support installing Bazel for non x86 platforms.~

- I allow users to be able to build from the latest drake master. I see the benefit to be two fold, obviously some users might want to try the latest and greatest features of drake asap and the second, is that M1 Mac/ARM Ubuntu users, including users of Nvidia Jetson platforms can now use `drake-ros` directly

- Building from source is currently a requirement for non x86 platforms. Hopefully once drake maintainers start hosting `aarch64` binaries, this won't be a hard requirement. I believe it would make the user experience significantly better as drake is quite heavy to build.

This was my first pass at it. There might be some spillovers from my lab's reqs that might not be relevant here hehe. Any comments, suggestions and improvements are all welcome! Thanks! 

cc: @EricCousineau-TRI

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/272)
<!-- Reviewable:end -->
