### PR TITLE
[py] Make it easier to pass C++ node pointers in Python

### DIFF
--- a/bazel_ros2_rules/README.md
+++ b/bazel_ros2_rules/README.md
@@ -40,7 +40,7 @@ add_bazel_ros2_rules_dependencies()
 load("@bazel_ros2_rules//ros2:defs.bzl", "ros2_local_repository")
 ros2_local_repository(
     name = "ros2",
-    workspace = ["/opt/ros/<distro>"],
+    workspaces = ["/opt/ros/<distro>"],
 )
 ```
 

--- a/drake_ros/core/drake_ros.cc
+++ b/drake_ros/core/drake_ros.cc
@@ -11,7 +11,7 @@ namespace drake_ros {
 namespace core {
 struct DrakeRos::Impl {
   rclcpp::Context::SharedPtr context;
-  rclcpp::Node::UniquePtr node;
+  rclcpp::Node::SharedPtr node;
   rclcpp::executors::SingleThreadedExecutor::UniquePtr executor;
 };
 

--- a/drake_ros/drake_ros/BUILD.bazel
+++ b/drake_ros/drake_ros/BUILD.bazel
@@ -57,11 +57,14 @@ pybind_py_library(
         "@ros2//:rclcpp_cc",
         "@ros2//:std_msgs_cc",
     ],
-    cc_so_name = "test_pub_and_sub_cc",
+    # See comment in neighboring CMakeLists.txt as to why we name organize this
+    # Python module in this fashion.
+    cc_so_name = "test/drake_ros_test_pub_and_sub_cc",
     cc_srcs = ["test/test_pub_and_sub_cc_py.cc"],
     py_deps = [
         ":drake_ros_py",
     ],
+    py_imports = ["test"],
 )
 
 ros_py_test(

--- a/drake_ros/drake_ros/BUILD.bazel
+++ b/drake_ros/drake_ros/BUILD.bazel
@@ -19,6 +19,7 @@ pybind_py_library(
     cc_deps = [
         ":python_bindings_internal_hdrs",
         "//:drake_ros_shared_library",
+        "@drake//bindings/pydrake:pydrake_pybind",
     ],
     cc_so_name = "_cc",
     cc_srcs = [
@@ -48,14 +49,31 @@ py_library(
     ],
 )
 
+pybind_py_library(
+    name = "test_pub_and_sub_cc_py",
+    testonly = 1,
+    cc_deps = [
+        ":python_bindings_internal_hdrs",
+        "@ros2//:rclcpp_cc",
+        "@ros2//:std_msgs_cc",
+    ],
+    cc_so_name = "test_pub_and_sub_cc",
+    cc_srcs = ["test/test_pub_and_sub_cc_py.cc"],
+    py_deps = [
+        ":drake_ros_py",
+    ],
+)
+
 ros_py_test(
     name = "core_test",
     srcs = ["test/core_test.py"],
     main = "test/core_test.py",
     deps = [
         ":drake_ros_py",
+        ":test_pub_and_sub_cc_py",
         "@drake//bindings/pydrake",
         "@ros2//:rclpy_py",
+        "@ros2//:std_msgs_py",
         "@ros2//:test_msgs_py",
         "@ros2//resources/rmw_isolation:rmw_isolation_py",
     ],

--- a/drake_ros/drake_ros/CMakeLists.txt
+++ b/drake_ros/drake_ros/CMakeLists.txt
@@ -28,6 +28,23 @@ if(BUILD_TESTING)
   find_package(Python3 COMPONENTS Interpreter)
   find_package(ament_cmake_test REQUIRED)
 
+  # TODO(eric.cousineau): I am not sure how to place a test-only Python library
+  # within a non-test ament package. To that end, we make this an independent
+  # Python package.
+  pybind11_add_module(py_test_pub_and_sub_cc SHARED
+    "test/test_pub_and_sub_cc_py.cc"
+  )
+  target_link_libraries(py_test_pub_and_sub_cc PRIVATE
+      drake_ros_core)
+  set_target_properties(py_test_pub_and_sub_cc
+    PROPERTIES
+      OUTPUT_NAME "drake_ros_test_pub_and_sub_cc"
+      LIBRARY_OUTPUT_DIRECTORY "${PROJECT_BINARY_DIR}/py/")
+  target_include_directories(py_test_pub_and_sub_cc
+    PRIVATE
+      "$<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}>"
+  )
+
   macro(add_python_test test_name test_file)
     # Invoke Pytest in a way that prevents source space from
     # Getting added to `sys.path`, so that CPython extensions
@@ -41,7 +58,9 @@ if(BUILD_TESTING)
         "--junit-prefix=drake_ros"
       # Let Python import mock-install structure in build folder
       WORKING_DIRECTORY
-        "${PROJECT_BINARY_DIR}/py/")
+        "${PROJECT_BINARY_DIR}/py/"
+      APPEND_ENV
+        "PYTHONPATH=${PROJECT_BINARY_DIR}/py/")
   endmacro()
 
   add_python_test(core_test_py test/core_test.py)

--- a/drake_ros/drake_ros/core/__init__.py
+++ b/drake_ros/drake_ros/core/__init__.py
@@ -2,6 +2,9 @@
 
 from drake_ros._cc.core import ClockSystem
 from drake_ros._cc.core import init
+from drake_ros._cc.core import CppNode
+from drake_ros._cc.core import CppNodeOptions
+from drake_ros._cc.core import DrakeRos
 from drake_ros._cc.core import Isometry3ToRosPose
 from drake_ros._cc.core import Isometry3ToRosTransform
 from drake_ros._cc.core import QuaternionToRosQuaternion
@@ -42,6 +45,12 @@ from pydrake.systems.framework import TriggerType
 from rclpy.serialization import serialize_message
 from rclpy.serialization import deserialize_message
 from rclpy.type_support import check_for_type_support
+
+
+def _setattr_kwargs(obj, kwargs):
+    # For `ParamInit` in `drake_ros_pybind.h`.
+    for name, value in kwargs.items():
+        setattr(obj, name, value)
 
 
 class PySerializer(SerializerInterface):

--- a/drake_ros/drake_ros/drake_ros_pybind.h
+++ b/drake_ros/drake_ros/drake_ros_pybind.h
@@ -17,6 +17,20 @@ namespace drake_ros_py DRAKE_ROS_NO_EXPORT {
 
 namespace py = pybind11;
 
+/**
+Imported from pydrake_pybind.h
+*/
+template <typename Class>
+auto ParamInit() {
+  return py::init([](py::kwargs kwargs) {
+    Class obj{};
+    py::object py_obj = py::cast(&obj, py::return_value_policy::reference);
+    py::module m = py::module::import("drake_ros.core");
+    m.attr("_setattr_kwargs")(py_obj, kwargs);
+    return obj;
+  });
+}
+
 // clang-format off
 }  // namespace drake_ros_py
 // clang-format on

--- a/drake_ros/drake_ros/test/core_test.py
+++ b/drake_ros/drake_ros/test/core_test.py
@@ -23,7 +23,7 @@ from drake_ros.core import DrakeRos
 from drake_ros.core import RosInterfaceSystem
 from drake_ros.core import RosPublisherSystem
 from drake_ros.core import RosSubscriberSystem
-from drake_ros.test_pub_and_sub_cc import CppPubAndSub
+from drake_ros_test_pub_and_sub_cc import CppPubAndSub
 
 
 def isolate_if_using_bazel():
@@ -36,9 +36,11 @@ def isolate_if_using_bazel():
 @pytest.fixture
 def drake_ros_fixture():
     drake_ros.core.init()
+    rclpy.init()
     try:
         yield
     finally:
+        rclpy.shutdown()
         drake_ros.core.shutdown()
 
 
@@ -72,7 +74,6 @@ def test_nominal_case(drake_ros_fixture):
 
     simulator_context = simulator.get_mutable_context()
 
-    rclpy.init()
     direct_ros_node = rclpy.create_node('sub_to_pub_py')
 
     # Create publisher talking to subscriber system.
@@ -138,7 +139,7 @@ def test_cpp_node(drake_ros_fixture):
     fixture = CppPubAndSub(node=node_cpp)
     # Show that we can publish from C++ to Python.
     fixture.Publish(value=10)
-    rclpy.spin_once(node_py, timeout_sec=1e-6)
+    rclpy.spin_once(node_py, timeout_sec=0.)
     assert sub_value == 10
     message = Int32()
     message.data = 100

--- a/drake_ros/drake_ros/test/core_test.py
+++ b/drake_ros/drake_ros/test/core_test.py
@@ -125,9 +125,9 @@ def assert_equal_for_cyclone_dds(actual, expected, name):
     if is_cyclone_dds:
         assert actual == expected
     else:
-        # TODO(eric.cousineau): At least for rmw_fastrtps_cpp, the behavior of
-        # publishing and receiving a message seems much less reliable than
-        # cyclone. Demote errors to warnings in this case.
+        # TODO(#286): At least for rmw_fastrtps_cpp, the behavior of publishing
+        # and receiving a message seems much less reliable than cyclone. Demote
+        # errors to warnings in this case.
         if actual != expected:
             warnings.warn(
                 f"WARNING! For RMW_IMPLEMENTATION={rmw_implementation}, "

--- a/drake_ros/drake_ros/test/test_pub_and_sub_cc_py.cc
+++ b/drake_ros/drake_ros/test/test_pub_and_sub_cc_py.cc
@@ -24,8 +24,11 @@ class CppPubAndSub {
     pub_->publish(std::move(message));
   }
 
-  int SpinAndReturnLatest() {
-    rclcpp::spin_some(node_);
+  int SpinAndReturnLatest(double timeout_sec) {
+    rclcpp::executors::SingleThreadedExecutor exec;
+    exec.add_node(node_);
+    const std::chrono::nanoseconds timeout(static_cast<int>(timeout_sec * 1e9));
+    exec.spin_some(timeout);
     return value_;
   }
 
@@ -42,7 +45,8 @@ PYBIND11_MODULE(drake_ros_test_pub_and_sub_cc, m) {
   py::class_<CppPubAndSub>(m, "CppPubAndSub")
       .def(py::init<rclcpp::Node::SharedPtr>(), py::arg("node"))
       .def("Publish", &CppPubAndSub::Publish, py::arg("value"))
-      .def("SpinAndReturnLatest", &CppPubAndSub::SpinAndReturnLatest);
+      .def("SpinAndReturnLatest", &CppPubAndSub::SpinAndReturnLatest,
+           py::arg("timeout_sec"));
 }
 
 }  // namespace

--- a/drake_ros/drake_ros/test/test_pub_and_sub_cc_py.cc
+++ b/drake_ros/drake_ros/test/test_pub_and_sub_cc_py.cc
@@ -12,7 +12,7 @@ using std_msgs::msg::Int32;
 
 class CppPubAndSub {
  public:
-  CppPubAndSub(rclcpp::Node::SharedPtr node) : node_(node) {
+  explicit CppPubAndSub(rclcpp::Node::SharedPtr node) : node_(node) {
     sub_ = node_->create_subscription<Int32>(
         "/cpp_sub", 1, [this](const Int32& message) { value_ = message.data; });
     pub_ = node_->create_publisher<Int32>("/cpp_pub", 1);
@@ -36,7 +36,7 @@ class CppPubAndSub {
   int value_{-1};
 };
 
-PYBIND11_MODULE(test_pub_and_sub_cc, m) {
+PYBIND11_MODULE(drake_ros_test_pub_and_sub_cc, m) {
   py::module_::import("drake_ros.core");
 
   py::class_<CppPubAndSub>(m, "CppPubAndSub")

--- a/drake_ros/drake_ros/test/test_pub_and_sub_cc_py.cc
+++ b/drake_ros/drake_ros/test/test_pub_and_sub_cc_py.cc
@@ -1,0 +1,52 @@
+#include <pybind11/pybind11.h>
+#include <rclcpp/rclcpp.hpp>
+#include <std_msgs/msg/int32.hpp>
+
+#include "drake_ros/drake_ros_pybind.h"
+
+namespace drake_ros {
+namespace drake_ros_py {
+namespace {
+
+using std_msgs::msg::Int32;
+
+class CppPubAndSub {
+ public:
+  CppPubAndSub(rclcpp::Node::SharedPtr node) : node_(node) {
+    sub_ = node_->create_subscription<Int32>(
+        "/cpp_sub", 1, [this](const Int32& message) { value_ = message.data; });
+    pub_ = node_->create_publisher<Int32>("/cpp_pub", 1);
+  }
+
+  void Publish(int value) {
+    Int32 message{};
+    message.data = value;
+    pub_->publish(std::move(message));
+  }
+
+  int SpinAndReturnLatest() {
+    rclcpp::spin_some(node_);
+    return value_;
+  }
+
+ private:
+  rclcpp::Node::SharedPtr node_;
+  rclcpp::Subscription<Int32>::SharedPtr sub_;
+  rclcpp::Publisher<Int32>::SharedPtr pub_;
+  int value_{-1};
+};
+
+PYBIND11_MODULE(test_pub_and_sub_cc, m) {
+  py::module_::import("drake_ros.core");
+
+  py::class_<CppPubAndSub>(m, "CppPubAndSub")
+      .def(py::init<rclcpp::Node::SharedPtr>(), py::arg("node"))
+      .def("Publish", &CppPubAndSub::Publish, py::arg("value"))
+      .def("SpinAndReturnLatest", &CppPubAndSub::SpinAndReturnLatest);
+}
+
+}  // namespace
+// clang-format off
+}  // namespace drake_ros_py
+// clang-format on
+}  // namespace drake_ros

--- a/ros2_example_bazel_installed/setup/prereq-rosdep-keys.txt
+++ b/ros2_example_bazel_installed/setup/prereq-rosdep-keys.txt
@@ -21,6 +21,7 @@ liborocos-kdl-dev
 libqt5-core
 libqt5-gui
 libqt5-opengl
+libqt5-svg
 libqt5-widgets
 libsqlite3-dev
 libx11-dev
@@ -63,6 +64,7 @@ python3-pytest
 python3-qt5-bindings
 python3-rosdistro-modules
 python3-setuptools
+python3-vcstool
 python3-yaml
 qtbase5-dev
 spdlog


### PR DESCRIPTION
I would like to not get too creative when trying to bind C++ code that has `rclcpp::Node` arguments. This is one approach.
Relates https://github.com/ros2/rclpy/issues/291

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/285)
<!-- Reviewable:end -->
