### PR TITLE
Add ROS2 Launch Files to all relevant examples 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 bazel-*
+**/__pycache__/
 
 # User-specified configuration
 /bazel_ros2_rules/user.bazelrc

--- a/drake_ros_examples/examples/hydroelastic/CMakeLists.txt
+++ b/drake_ros_examples/examples/hydroelastic/CMakeLists.txt
@@ -16,3 +16,9 @@ install(FILES
   hydroelastic.rviz
   DESTINATION share/${PROJECT_NAME}/hydroelastic/
 )
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+  FILES_MATCHING PATTERN "*_launch.py"
+)

--- a/drake_ros_examples/examples/hydroelastic/README.md
+++ b/drake_ros_examples/examples/hydroelastic/README.md
@@ -32,8 +32,13 @@ bazel run @ros2//:rviz2 -- -d `pwd`/examples/hydroelastic/hydroelastic.rviz
 # Using Colcon/CMake
 rviz2 -d `ros2 pkg prefix --share drake_ros_examples`/hydroelastic/hydroelastic.rviz
 ```
+Or use ROS 2 Launch:
+```sh
+# Using ROS 2 Launch (C++)
+ros2 launch drake_ros_examples hydroelastic_cc_launch.py
+```
 
-You can optionall enable visualizng the simulation with Meshcat.
+You can optionally enable visualizng the simulation with Meshcat.
 
 ```bash
 # Using bazel

--- a/drake_ros_examples/examples/hydroelastic/launch/hydroelastic_cc_launch.py
+++ b/drake_ros_examples/examples/hydroelastic/launch/hydroelastic_cc_launch.py
@@ -1,0 +1,23 @@
+import os
+
+from ament_index_python.packages import get_package_prefix
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+
+def generate_launch_description():
+    rviz_config_file = os.path.join(get_package_share_directory('drake_ros_examples'), 'hydroelastic/hydroelastic.rviz')
+
+    rviz_node = ExecuteProcess(
+        cmd=['rviz2', '-d', rviz_config_file],
+        output='screen'
+    )
+
+    hydroelastic_cpp_node = ExecuteProcess(
+        cmd=[os.path.join(get_package_prefix('drake_ros_examples'), 'lib', 'drake_ros_examples', 'hydroelastic')],
+    )
+    return LaunchDescription([
+        rviz_node,
+        hydroelastic_cpp_node,
+    ])

--- a/drake_ros_examples/examples/iiwa_manipulator/CMakeLists.txt
+++ b/drake_ros_examples/examples/iiwa_manipulator/CMakeLists.txt
@@ -21,3 +21,9 @@ install(
   FILES iiwa_manipulator.rviz
   DESTINATION share/${PROJECT_NAME}
 )
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+  FILES_MATCHING PATTERN "*_launch.py"
+)

--- a/drake_ros_examples/examples/iiwa_manipulator/README.md
+++ b/drake_ros_examples/examples/iiwa_manipulator/README.md
@@ -35,7 +35,13 @@ bazel run //examples/iiwa_manipulator:iiwa_manipulator
 # Python
 bazel run //examples/iiwa_manipulator:iiwa_manipulator_py
 ```
-
+Or
+```sh
+# Using ROS 2 Launch (C++)
+ros2 launch drake_ros_examples iiwa_manipulator_cc_launch.py
+# or (Python)
+ros2 launch drake_ros_examples iiwa_manipulator_py_launch.py
+```
 You should see the manipulation station with simple sinusoidal motion.
 
 **Note***: If you restart the simulation but not RViz, you should click RViz's

--- a/drake_ros_examples/examples/iiwa_manipulator/launch/iiwa_manipulator_cc_launch.py
+++ b/drake_ros_examples/examples/iiwa_manipulator/launch/iiwa_manipulator_cc_launch.py
@@ -1,0 +1,23 @@
+import os
+
+from ament_index_python.packages import get_package_prefix
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+
+def generate_launch_description():
+    rviz_config_file = os.path.join(get_package_share_directory('drake_ros_examples'), 'iiwa_manipulator.rviz')
+
+    rviz_node = ExecuteProcess(
+        cmd=['rviz2', '-d', rviz_config_file],
+        output='screen'
+    )
+
+    iiwa_manipulator_cpp_node = ExecuteProcess(
+        cmd=[os.path.join(get_package_prefix('drake_ros_examples'), 'lib', 'drake_ros_examples', 'iiwa_manipulator')],
+    )
+    return LaunchDescription([
+        rviz_node,
+        iiwa_manipulator_cpp_node,
+    ])

--- a/drake_ros_examples/examples/iiwa_manipulator/launch/iiwa_manipulator_py_launch.py
+++ b/drake_ros_examples/examples/iiwa_manipulator/launch/iiwa_manipulator_py_launch.py
@@ -1,0 +1,23 @@
+import os
+
+from ament_index_python.packages import get_package_prefix
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+
+def generate_launch_description():
+    rviz_config_file = os.path.join(get_package_share_directory('drake_ros_examples'), 'iiwa_manipulator.rviz')
+
+    rviz_node = ExecuteProcess(
+        cmd=['rviz2', '-d', rviz_config_file],
+        output='screen'
+    )
+
+    iiwa_manipulator_py_node = ExecuteProcess(
+        cmd=[os.path.join(get_package_prefix('drake_ros_examples'), 'lib', 'drake_ros_examples', 'iiwa_manipulator.py')],
+    )
+    return LaunchDescription([
+        rviz_node,
+        iiwa_manipulator_py_node,
+    ])

--- a/drake_ros_examples/examples/multirobot/CMakeLists.txt
+++ b/drake_ros_examples/examples/multirobot/CMakeLists.txt
@@ -21,3 +21,9 @@ install(
   FILES multirobot.rviz
   DESTINATION share/${PROJECT_NAME}
 )
+
+install(
+  DIRECTORY launch
+  DESTINATION share/${PROJECT_NAME}
+  FILES_MATCHING PATTERN "*_launch.py"
+)

--- a/drake_ros_examples/examples/multirobot/README.md
+++ b/drake_ros_examples/examples/multirobot/README.md
@@ -39,6 +39,13 @@ bazel run //examples/multirobot:multirobot
 # Python
 bazel run //examples/multirobot:multirobot_py
 ```
+Or use ROS 2 Launch:
+```sh
+# Using ROS 2 Launch (C++)
+ros2 launch drake_ros_examples multirobot_cc_launch.py
+# or (Python)
+ros2 launch drake_ros_examples multirobot_py_launch.py
+``` 
 
 You should observe a 5 x 5 array of manipulators flopping about under the influence of gravity.
 

--- a/drake_ros_examples/examples/multirobot/launch/multirobot_cc_launch.py
+++ b/drake_ros_examples/examples/multirobot/launch/multirobot_cc_launch.py
@@ -1,0 +1,24 @@
+import os
+
+from ament_index_python.packages import get_package_prefix
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+
+def generate_launch_description():
+    rviz_config_file = os.path.join(get_package_share_directory('drake_ros_examples'), 'multirobot.rviz')
+
+    rviz_node = ExecuteProcess(
+        cmd=['rviz2', '-d', rviz_config_file],
+        output='screen'
+    )
+
+    multirobot_cpp_node = ExecuteProcess(
+        cmd=[os.path.join(get_package_prefix('drake_ros_examples'), 'lib', 'drake_ros_examples', 'multirobot')],
+    )
+
+    return LaunchDescription([
+        rviz_node,
+        multirobot_cpp_node,
+    ])

--- a/drake_ros_examples/examples/multirobot/launch/multirobot_py_launch.py
+++ b/drake_ros_examples/examples/multirobot/launch/multirobot_py_launch.py
@@ -1,0 +1,24 @@
+import os
+
+from ament_index_python.packages import get_package_prefix
+from ament_index_python.packages import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import ExecuteProcess
+
+
+def generate_launch_description():
+    rviz_config_file = os.path.join(get_package_share_directory('drake_ros_examples'), 'multirobot.rviz')
+
+    rviz_node = ExecuteProcess(
+        cmd=['rviz2', '-d', rviz_config_file],
+        output='screen'
+    )
+
+    multirobot_py_node = ExecuteProcess(
+        cmd=[os.path.join(get_package_prefix('drake_ros_examples'), 'lib', 'drake_ros_examples', 'multirobot.py')],
+    )
+
+    return LaunchDescription([
+        rviz_node,
+        multirobot_py_node,
+    ])


### PR DESCRIPTION
This PR adds launch files to all the examples that involve a visual (`rviz`) component. All the launch files were tested.

@EricCousineau-TRI for review, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/289)
<!-- Reviewable:end -->
