### PR TITLE
[fix] Multirobot cpp version doesn't create the correct plant setup and viz 

### DIFF
--- a/drake_ros_examples/examples/multirobot/multirobot.cc
+++ b/drake_ros_examples/examples/multirobot/multirobot.cc
@@ -74,12 +74,12 @@ int main(int argc, char** argv) {
   const std::string model_name = "kuka_iiwa";
 
   // Create a 5x5 array of manipulators
-  size_t kNumRows = 5;
-  size_t kNumCols = 5;
+  int kNumRows = 5;
+  int kNumCols = 5;
   std::vector<std::vector<drake::multibody::ModelInstanceIndex>> models;
-  for (uint8_t xx = 0; xx < kNumRows; ++xx) {
+  for (int xx = 0; xx < kNumRows; ++xx) {
     std::vector<drake::multibody::ModelInstanceIndex> models_xx;
-    for (uint8_t yy = 0; yy < kNumCols; ++yy) {
+    for (int yy = 0; yy < kNumCols; ++yy) {
       // Load the model from the file and give it a name based on its X and Y
       // coordinates in the array
       std::stringstream model_instance_name;
@@ -102,8 +102,8 @@ int main(int argc, char** argv) {
   plant.Finalize();
 
   // Set the control input of each robot to uncontrolled
-  for (size_t xx = 0; xx < kNumRows; ++xx) {
-    for (size_t yy = 0; yy < kNumCols; ++yy) {
+  for (int xx = 0; xx < kNumRows; ++xx) {
+    for (int yy = 0; yy < kNumCols; ++yy) {
       // Get the number of degrees of freedom for the robot
       auto num_dofs = plant.num_actuated_dofs(models[xx][yy]);
       // Create a vector with the same number of zeros


### PR DESCRIPTION
As of now, currently the `multirobot` (cpp) version creates a 4x4 grid as compared to what it should be, a 5x5 one. The Python version works as expected. I have attached the videos which show the fewer robots + amputated kukas. 

Working Python version - 

https://github.com/RobotLocomotion/drake-ros/assets/38449494/7bab1543-740d-4146-9b44-b91d2e0db967

Broken Cpp version- 

https://github.com/RobotLocomotion/drake-ros/assets/38449494/f08671f0-83de-49b4-9d35-e33ffa8f963e

My guess is that `uint8_t` being compared with `size_t` seems to be the culprit. Although ideally it shouldn't, however, maybe it's some compiler settings that makes the treatment that ends up in this error?

cc: @EricCousineau-TRI for review, thanks!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/290)
<!-- Reviewable:end -->
