### PR TITLE
Handle cmake failures in dependent packages

### DIFF
--- a/bazel_ros2_rules/ros2/resources/cmake_tools/file_api.py
+++ b/bazel_ros2_rules/ros2/resources/cmake_tools/file_api.py
@@ -123,7 +123,9 @@ def get_cmake_codemodel(project_path: Path, build_path: Path) -> CodeModel:
     query_path.joinpath('codemodel-v2').touch()
 
     args = ['cmake', str(project_path)]
-    subprocess.run(args, cwd=str(build_path))
+    result = subprocess.run(args, cwd=str(build_path))
+    if result.returncode != 0:
+        raise RuntimeError("CMake error occurred on project. See build logs")
 
     # There should only be one file, but just in case the latest is the
     # largest file in lexicographic order.

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_cmake.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/ament_cmake.py
@@ -152,7 +152,10 @@ def collect_ament_cmake_package_properties(name, metadata):
         project_path = Path(project_path)
         build_path = project_path.joinpath('build')
         build_path.mkdir()
-        codemodel = cmake_tools.get_cmake_codemodel(project_path, build_path)
+        try:
+            codemodel = cmake_tools.get_cmake_codemodel(project_path, build_path)
+        except RuntimeError as e:
+            raise RuntimeError(f"Error occured while generating build for {name}")
 
         # Should only be one SHARED_LIBRARY target
         target = None


### PR DESCRIPTION
CMake fails for many packages in the default ros2 humble install, leaving expected cmake api query results empty. This handles the failure and surfaces the name of the failing package for investigation.

In order to artificially generate errors, leave `include_packages` empty in a `ros2_local_repository` instance to pull in all installed packages. Many will have cmake failures.

To see the specific errors I encountered, apply the following change to the `//ros2_example_bazel_installed:WORKSPACE`  and run `bazel build //...` from `ros2_example_bazel_installed`

```
 ros2_local_repository(
     name = "ros2" if ROS2_DISTRO_PREFIX else "ros2_ignored",
-    include_packages = ROS2_PACKAGES,
+    # include_packages = ROS2_PACKAGES,
     workspaces = [ROS2_DISTRO_PREFIX],
 )
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/300)
<!-- Reviewable:end -->
