### PR TITLE
Update ubuntu version in bazelized_drake_ros.yml

### DIFF
--- a/.github/workflows/bazelized.yml
+++ b/.github/workflows/bazelized.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   bazel_build_and_test:
     if: "! contains(github.event.pull_request.labels.*.name, 'status: defer ci')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     container:
       image: ros:rolling-ros-base-jammy
       # This is required for running lldb.

--- a/.github/workflows/bazelized_drake_ros.yml
+++ b/.github/workflows/bazelized_drake_ros.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   bazel_build_and_test:
     if: "! contains(github.event.pull_request.labels.*.name, 'status: defer ci')"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3
@@ -22,6 +22,8 @@ jobs:
           key: bazel
       - name: Check cache
         run: du -hs $(readlink -f /home/runner/.cache/ci)
+      - name: Remove needrestart
+        run: sudo apt remove -y needrestart
       - name: Simplify apt upgrades
         run: .github/simplify_apt_and_upgrades.sh
       - name: Configure drake_ros Bazel for CI

--- a/.github/workflows/bazelized_drake_ros.yml
+++ b/.github/workflows/bazelized_drake_ros.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   bazel_build_and_test:
     if: "! contains(github.event.pull_request.labels.*.name, 'status: defer ci')"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/cache@v3

--- a/.github/workflows/bazelized_drake_ros.yml
+++ b/.github/workflows/bazelized_drake_ros.yml
@@ -22,8 +22,6 @@ jobs:
           key: bazel
       - name: Check cache
         run: du -hs $(readlink -f /home/runner/.cache/ci)
-      - name: Remove needrestart
-        run: sudo apt remove -y needrestart
       - name: Simplify apt upgrades
         run: .github/simplify_apt_and_upgrades.sh
       - name: Configure drake_ros Bazel for CI
@@ -53,6 +51,9 @@ jobs:
         working-directory: drake_ros
       - name: Test drake_ros
         run: bazel test //...
+        working-directory: drake_ros
+      - name: Clean up drake_ros
+        run: bazel clean
         working-directory: drake_ros
       # CI for drake_ros_examples.
       - name: Install additional ROS dependencies for drake_ros_examples


### PR DESCRIPTION
Fixes CI due to ubuntu version mismatch. Old libs require a restart after an upgrade which makes the CI jobs fail.

``bazelized.yaml`` uses ``ubuntu-latest`` and ``bazelized_drake_ros.yaml`` uses ``ubuntu-22.04`` which probably point to different versions now. This PR makes the versions consistent, using latest on both. I'd personally prefer specifying the exact version of ubuntu to be used, but I'm open for suggestions.

EDIT : Use ubuntu-22.04 in both CI jobs, and remove ``needrestart``

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/301)
<!-- Reviewable:end -->
