### PR TITLE
[ci] Free up disk space on GitHub CI runner

### DIFF
--- a/.github/runner_free_space.sh
+++ b/.github/runner_free_space.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -eux
+
+# Adapted from https://stackoverflow.com/a/76211564
+# TODO(eric.cousineau): Try using
+# https://github.com/easimon/maximize-build-space
+
+df -h
+sudo docker rmi $(docker image ls -aq) >/dev/null 2>&1
+df -h /
+sudo rm -rf \
+  /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+  /usr/local/share/powershell /usr/share/swift /usr/local/.ghcup \
+  /usr/lib/jvm
+df -h /

--- a/.github/workflows/bazelized_drake_ros.yml
+++ b/.github/workflows/bazelized_drake_ros.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
+      - name: Free up space
+        run: .github/runner_free_space.sh
 
       # Caching.
       # See comments in drake-blender for more details:
@@ -43,7 +45,9 @@ jobs:
         run: rosdep update
       - name: Install bazel_ros2_rules dependencies
         # TODO(sloretz) make bazel_ros2_rules/setup/install_prereqs.sh
-        run: sudo apt install python3 python3-toposort
+        run: |
+          sudo apt install python3 python3-toposort
+          sudo rm -rf /var/lib/apt/lists/*
       - name: Download Drake
         run: bazel build @drake//:module_py
         working-directory: drake_ros
@@ -54,7 +58,9 @@ jobs:
         # TODO(sloretz) can't use rosdep here because we need the archive downloaded,
         # but can't download the archive with bazel until we have the dependencies installed
         # so bazel_ros2_rules can inspect it.
-        run: sudo apt-get install -y libconsole-bridge-dev
+        run: |
+          sudo apt-get install -y libconsole-bridge-dev
+          sudo rm -rf /var/lib/apt/lists/*
       # CI for drake_ros.
       - name: Build drake_ros
         run: bazel build //...
@@ -67,7 +73,9 @@ jobs:
         working-directory: drake_ros
       # CI for drake_ros_examples.
       - name: Install additional ROS dependencies for drake_ros_examples
-        run: yes | sudo ./setup/install_prereqs.sh
+        run: |
+          yes | sudo ./setup/install_prereqs.sh
+          sudo rm -rf /var/lib/apt/lists/*
         working-directory: drake_ros_examples
       - name: Configure drake_ros_examples Bazel for CI
         run: ln -s ../.github/ci.bazelrc ./user.bazelrc

--- a/drake_ros_examples/setup/install_prereqs.sh
+++ b/drake_ros_examples/setup/install_prereqs.sh
@@ -9,4 +9,5 @@ apt_install () {
   apt-get -q install --no-install-recommends "$@"
 }
 
+apt-get update
 apt_install $(cat_without_comments packages-ros2.txt)


### PR DESCRIPTION
Towards #247

EDIT: Currently shown at the start:
```sh
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   61G   23G  74% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  31% /mnt
tmpfs           693M   12K  693M   1% /run/user/1001
```

After build + test + clean of `drake_ros`, then install prereqs of `drake_ros_examples`:
```sh
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   74G  9.3G  89% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.2M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sda15      105M  6.1M   99M   6% /boot/efi
/dev/sdb1        14G  4.1G  9.0G  31% /mnt
tmpfs           693M   12K  693M   1% /run/user/1001
```

After freeing up space (took ~3m):
```sh
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        84G   28G   56G  34% /
tmpfs           3.4G  172K  3.4G   1% /dev/shm
tmpfs           1.4G  1.1M  1.4G   1% /run
tmpfs           5.0M     0  5.0M   0% /run/lock
/dev/sdb15      105M  6.1M   99M   6% /boot/efi
/dev/sda1        14G  4.1G  9.0G  31% /mnt
tmpfs           693M   12K  693M   1% /run/user/1001
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/309)
<!-- Reviewable:end -->
