### PR TITLE
[ci] Share cache in all directions for bazelized_drake_ros

### DIFF
--- a/.github/workflows/bazelized_drake_ros.yml
+++ b/.github/workflows/bazelized_drake_ros.yml
@@ -27,9 +27,11 @@ jobs:
           path: "~/.cache/bazel_ci"
           # We want this key to change to ensure we store the updated cache.
           key: bazel_ci-${{ github.ref }}-${{ github.run_number }}-${{ github.run_attempt }}
+          # N.B. We share in all directions (main -> PR, and PR -> main). This
+          # should only cause an issue if we encounter cache poisoning, which
+          # should not be too frequent (if at all).
           restore-keys: |
-            bazel_ci-${{ github.ref }}-
-            bazel_ci-refs/heads/main-
+            bazel_ci-
       - name: Check cache
         run: du -hs $(readlink -f ~/.cache/bazel_ci) || true
 


### PR DESCRIPTION
Otherwise, mainline CI can be a tad slow, e.g.
https://github.com/RobotLocomotion/drake-ros/commit/058f09b0956666f8346b27053aa3970782665aa6
https://github.com/RobotLocomotion/drake-ros/actions/runs/6693361651/job/18184334483

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/310)
<!-- Reviewable:end -->
