### PR TITLE
Show `ros2 bag record` failing on custom message types

### DIFF
--- a/ros2_example_bazel_installed/WORKSPACE
+++ b/ros2_example_bazel_installed/WORKSPACE
@@ -72,6 +72,7 @@ ROS2_PACKAGES = [
     "rclpy",
     "ros2cli",
     "ros2cli_common_extensions",
+    "rosbag2",
     "rosidl_default_generators",
     "tf2_py",
 ] + [

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -243,6 +243,24 @@ ros_py_test(
 )
 
 ros_py_test(
+    name = "custom_message_rosbag_test",
+    srcs = ["test/custom_message_rosbag_test.py"],
+    data = [
+        # Provide both Python and C++ IDL to see if it can get picked up...
+        ":ros2_example_apps_msgs_py",
+        ":ros2_example_apps_msgs_cc",
+        # Binaries to run.
+        ":simple_talker",
+        "@ros2",
+    ],
+    main = "test/custom_message_rosbag_test.py",
+    deps = [
+        "@bazel_tools//tools/python/runfiles",
+        "@ros2//resources/rmw_isolation:rmw_isolation_py",
+    ],
+)
+
+ros_py_test(
     name = "rmw_isolation_example_py_test",
     srcs = ["test/rmw_isolation_example.py"],
     data = [

--- a/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_rosbag_test.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/test/custom_message_rosbag_test.py
@@ -1,0 +1,103 @@
+"""
+To run:
+
+    export ROS2_DISTRO_PREFIX=/opt/ros/humble
+    bazel test --nocache_test_results --test_output=streamed //ros2_example_apps:custom_message_rosbag_test
+
+OR
+
+    export ROS2_DISTRO_PREFIX=/opt/ros/humble
+    bazel build //ros2_example_apps:custom_message_rosbag_test
+    bazel-bin/ros2_example_apps/custom_message_rosbag_test
+
+WARNING: `bazel run` does not work as expected
+"""
+
+import os
+import shutil
+import select
+import subprocess
+import time
+
+from bazel_tools.tools.python.runfiles import runfiles
+from rmw_isolation import isolate_rmw_by_path
+
+
+def read_available(f, timeout=0.0, chunk_size=1024):
+    """
+    Reads all available data on a given file. Useful for using PIPE with Popen.
+    """
+    readable, _, _ = select.select([f], [], [f], timeout)
+    out = None
+    if f in readable:
+        while True:
+            cur = os.read(f.fileno(), chunk_size)
+            if out is None:
+                out = cur
+            else:
+                out += cur
+            if len(cur) < chunk_size:
+                break
+    text = out.decode("utf-8")
+    return text
+
+
+def open_process(args):
+    return subprocess.Popen(
+        args,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        stdin=subprocess.PIPE,
+        text=True,
+    )
+
+
+def attempt_record():
+    if "TEST_TMPDIR" in os.environ:
+        tmp_dir = os.environ["TEST_TMPDIR"]
+        isolate_rmw_by_path(tmp_dir)
+        os.environ["ROS_HOME"] = os.path.join(tmp_dir)
+    else:
+        tmp_dir = "/tmp"
+
+    manifest = runfiles.Create()
+    ros2_bin = manifest.Rlocation("ros2/ros2")
+    assert ros2_bin is not None
+    talker_bin = manifest.Rlocation(
+        "ros2_example_bazel_installed/ros2_example_apps/simple_talker")
+    bag_dir = os.path.join(tmp_dir, "test_bag")
+    if os.path.exists(bag_dir):
+        shutil.rmtree(bag_dir)
+
+    try:
+        talker = open_process([talker_bin])
+        rosbag = open_process(
+            [ros2_bin, "bag", "record", "--all", "-o", bag_dir]
+        )
+
+        time.sleep(1.0)
+
+        assert talker.returncode is None, read_available(talker.stdout)
+        assert rosbag.returncode is None, read_available(rosbag.stdout)
+
+        text = read_available(rosbag.stdout)
+        return text
+    finally:
+        talker.kill()
+        rosbag.kill()
+
+
+def main():
+    text = attempt_record()
+    print(text)
+
+    assert "Recording..." in text
+    assert "Subscribed to topic '/status'" in text
+
+    # This is the error we're running into.
+    assert "has unknown type" not in text
+    assert "Failure in topics discovery" not in text
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Reproduces #311

```sh
cd ros2_example_bazel_installed
export ROS2_DISTRO_PREFIX=/opt/ros/humble
bazel test --nocache_test_results --test_output=streamed //ros2_example_apps:custom_message_rosbag_test
```

WARNING: `bazel run` does not work for the example. I don't know why, but it's not worth investigating at the moment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/312)
<!-- Reviewable:end -->
