### PR TITLE
Added missing rmw_implementation to simple_talker

### DIFF
--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -198,6 +198,7 @@ ros_py_binary(
         ":ros2_example_apps_msgs_py",
         "@ros2//:rclpy_py",
     ],
+    rmw_implementation = "rmw_cyclonedds_cpp",
 )
 
 # This shows how to ensure a Bazel-provided `ros2` CLI can print out custom


### PR DESCRIPTION
Missing `rmw_implementation` in `simple_talker.py`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/320)
<!-- Reviewable:end -->
