### PR TITLE
Support `extra_deps` arg for `rosidl` both `cc` and `py`

### DIFF
--- a/bazel_ros2_rules/ros2/rosidl.bzl
+++ b/bazel_ros2_rules/ros2/rosidl.bzl
@@ -1138,6 +1138,7 @@ def rosidl_cc_support(
         interfaces,
         data,
         deps,
+        extra_deps,
         group = None,
         cc_binary_rule = native.cc_binary,
         cc_library_rule = native.cc_library,
@@ -1165,7 +1166,7 @@ def rosidl_cc_support(
         group = group or name,
         interfaces = interfaces,
         includes = [_make_public_label(dep, "_defs") for dep in deps],
-        deps = [_make_public_label(dep, "_cc") for dep in deps],
+        deps = [_make_public_label(dep, "_cc") for dep in deps] + extra_deps,
         cc_library_rule = cc_library_rule,
         **kwargs
     )
@@ -1188,7 +1189,7 @@ def rosidl_cc_support(
             deps = [_make_private_label(name, "__rosidl_cpp")] + [
                 _make_public_label(dep, "_cc")
                 for dep in deps
-            ],
+            ] + extra_deps,
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
@@ -1222,7 +1223,7 @@ def rosidl_cc_support(
             deps = [_make_private_label(name, "__rosidl_cpp")] + [
                 _make_public_label(dep, "_cc")
                 for dep in deps
-            ],
+            ] + extra_deps,
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
@@ -1253,7 +1254,7 @@ def rosidl_cc_support(
         deps = [_make_private_label(name, "__rosidl_cpp")] + [
             _make_public_label(dep, "_cc")
             for dep in deps
-        ],
+        ] + extra_deps,
         cc_binary_rule = cc_binary_rule,
         **kwargs
     )
@@ -1278,7 +1279,7 @@ def rosidl_cc_support(
             _make_public_label(name, "__rosidl_typesupport_cpp"),
         ] + typesupports.values(),
         data = data,
-        deps = [_make_private_label(name, "__rosidl_cpp")],
+        deps = [_make_private_label(name, "__rosidl_cpp")] + extra_deps,
         linkstatic = True,
         **kwargs
     )
@@ -1288,6 +1289,7 @@ def rosidl_py_support(
         interfaces,
         data,
         deps,
+        extra_deps,
         group = None,
         cc_binary_rule = native.cc_binary,
         cc_library_rule = native.cc_library,
@@ -1317,7 +1319,7 @@ def rosidl_py_support(
         group = group or name,
         interfaces = interfaces,
         includes = [_make_public_label(dep, "_defs") for dep in deps],
-        deps = [_make_public_label(dep, "_c") for dep in deps],
+        deps = [_make_public_label(dep, "_c") for dep in deps] + extra_deps,
         cc_library_rule = cc_library_rule,
         **kwargs
     )
@@ -1340,7 +1342,7 @@ def rosidl_py_support(
             deps = [_make_private_label(name, "__rosidl_c")] + [
                 _make_public_label(dep, "_c")
                 for dep in deps
-            ],
+            ] + extra_deps,
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
@@ -1374,7 +1376,7 @@ def rosidl_py_support(
             deps = [_make_private_label(name, "__rosidl_c")] + [
                 _make_public_label(dep, "_c")
                 for dep in deps
-            ],
+            ] + extra_deps,
             cc_binary_rule = cc_binary_rule,
             cc_library_rule = cc_library_rule,
             **kwargs
@@ -1405,7 +1407,7 @@ def rosidl_py_support(
         deps = [_make_private_label(name, "__rosidl_c")] + [
             _make_public_label(dep, "_c")
             for dep in deps
-        ],
+        ] + extra_deps,
         cc_binary_rule = cc_binary_rule,
         **kwargs
     )
@@ -1431,7 +1433,7 @@ def rosidl_py_support(
         srcs = typesupports.values(),
         deps = [
             _make_private_label(name, "__rosidl_c"),
-        ] + typesupports.values(),
+        ] + typesupports.values() + extra_deps,
         linkstatic = True,
         **kwargs
     )
@@ -1447,7 +1449,7 @@ def rosidl_py_support(
         c_deps = [_make_public_label(name, "_c")] + [
             _make_public_label(dep, "_c")
             for dep in deps
-        ],
+        ] + extra_deps,
         cc_binary_rule = cc_binary_rule,
         cc_library_rule = cc_library_rule,
         py_library_rule = py_library_rule,
@@ -1459,6 +1461,7 @@ def rosidl_interfaces_group(
         interfaces,
         data = [],
         deps = [],
+        extra_deps = [],
         group = None,
         cc_binary_rule = native.cc_binary,
         cc_library_rule = native.cc_library,
@@ -1515,6 +1518,7 @@ def rosidl_interfaces_group(
         interfaces = interfaces,
         data = data,
         deps = deps,
+        extra_deps = extra_deps,
         group = group,
         cc_binary_rule = cc_binary_rule,
         cc_library_rule = cc_library_rule,
@@ -1528,6 +1532,7 @@ def rosidl_interfaces_group(
         # Add the C++ target so that we can support `ros2 bag record`.
         data = data + [cc_name],
         deps = deps,
+        extra_deps = extra_deps,
         group = group,
         cc_binary_rule = cc_binary_rule,
         cc_library_rule = cc_library_rule,


### PR DESCRIPTION
This stems from a problem I ran into yesterday, where `python_rules` `numpy` wasn't providing the `cpp` headers and I would end up in a following scenario - 
```
ali@bdai_docker:/workspaces/bdai/projects/dexterity$ bazel build //...
INFO: Options provided by the client:
  Inherited 'common' options: --isatty=1 --terminal_columns=103
INFO: Reading rc options for 'build' from /workspaces/bdai/projects/dexterity/.bazelrc:
  'build' options: --announce_rc --cxxopt=-std=c++20 --cxxopt=-Werror --cxxopt=-Wall --cxxopt=-Wextra --cxxopt=-Wdouble-promotion --cxxopt=-Wformat --cxxopt=-Wunused --cxxopt=-Wfloat-equal --cxxopt=-Wshadow --cxxopt=-Wconversion --cxxopt=-Winline --cxxopt=-Wno-variadic-macros --cxxopt=-Wnon-virtual-dtor --cxxopt=-Wpedantic --incompatible_strict_action_env --@aspect_rules_py//py:interpreter_version=3.10.12
INFO: Analyzed 59 targets (5 packages loaded, 10431 targets configured).
INFO: Found 59 targets...
ERROR: /workspaces/bdai/projects/dexterity/ws/src/mocap_print/BUILD:5:24: Compiling ws/src/mocap_print/mocap_generated_interfaces/py/mocap_generated_interfaces/msg/_marker_s.c failed: (Exit 1): gcc failed: error executing command (from target //ws/src/mocap_print:_mocap_generated_interfaces_py_c) /usr/bin/gcc -U_FORTIFY_SOURCE -fstack-protector -Wall -Wunused-but-set-parameter -Wno-free-nonheap-object -fno-omit-frame-pointer -MD -MF ... (remaining 110 arguments skipped)

Use --sandbox_debug to see verbose messages from the sandbox and retain the sandbox build root for debugging
bazel-out/k8-fastbuild/bin/ws/src/mocap_print/mocap_generated_interfaces/py/mocap_generated_interfaces/msg/_marker_s.c:11:10: fatal error: numpy/ndarrayobject.h: No such file or directory
   11 | #include "numpy/ndarrayobject.h"
      |          ^~~~~~~~~~~~~~~~~~~~~~~
      
  
```

 And unsurprisingly - 
```
ali@bdai_docker:/workspaces/bdai/projects/dexterity$ bazelisk query "@pypi_numpy//:*" | grep ndarrayobject
Loading: 0 packages loaded
@pypi_numpy//:site-packages/numpy/core/include/numpy/ndarrayobject.h
Loading: 0 packages loaded

```

Via this patch users would be able to provide the cc dependency as an extra. I don't think it's a perfect solution, but it is *a* solution that doesn't involve touching `python_rules` themselves. An example to use this would be - 

```
rosidl_interfaces_group(
    name = "mocap_generated_interfaces",
    interfaces = [
        "msg/RigidBody.msg",
        "msg/Marker.msg",
        "msg/RigidBodies.msg",
    ],
    visibility = ["//:__pkg__"],
    deps = [
        "@ros2//:builtin_interfaces",
        "@ros2//:geometry_msgs",
    ],
    extra_deps = [
        "@numpy_repo//:numpy_cc",
    ],
)
```

