### PR TITLE
remove extra ; that cause a warning

### DIFF
--- a/drake_ros/viz/scene_markers_system.cc
+++ b/drake_ros/viz/scene_markers_system.cc
@@ -36,7 +36,7 @@ namespace {
 /// Converts Drake shape descriptions to ROS Marker messages.
 class SceneGeometryToMarkers : public drake::geometry::ShapeReifier {
  public:
-  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SceneGeometryToMarkers);
+  DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SceneGeometryToMarkers)
 
   explicit SceneGeometryToMarkers(const SceneMarkersParams& params)
       : params_(params) {}


### PR DESCRIPTION
error message:
```bash
--- stderr: drake_ros
/workspace/codes/cc_control_ws/src/drake-ros/drake_ros/viz/scene_markers_system.cc:39:58: error: extra ‘;’ [-Werror=pedantic]
   39 |   DRAKE_NO_COPY_NO_MOVE_NO_ASSIGN(SceneGeometryToMarkers);
      |                                                          ^
      |                                                          -
cc1plus: all warnings being treated as errors
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/359)
<!-- Reviewable:end -->
