### PR TITLE
[cmake] Turn off -Werror=extra -Werror=pedantic

### DIFF
--- a/drake_ros/CMakeLists.txt
+++ b/drake_ros/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-error=deprecated-declarations)
+  add_compile_options(-Wall -Werror -Wno-error=deprecated-declarations)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)

--- a/drake_ros_examples/CMakeLists.txt
+++ b/drake_ros_examples/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT CMAKE_CXX_STANDARD)
 endif()
 
 if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-error=deprecated-declarations)
+  add_compile_options(-Wall -Werror -Wno-error=deprecated-declarations)
 endif()
 
 find_package(ament_cmake_ros REQUIRED)


### PR DESCRIPTION
In no universe should Werror be enabled in end-user builds (rather than just developers local builds and CI checks), and certainly not for warning categories that Drake's own CI doesn't even enable. We don't want *this* repository to be a warning-catcher for Drake code.

The easy fix for now is to just turn off the overly broad warning categories. This does not fix the bug that Werror=all is enabled for builds triggered by downstream users.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/360)
<!-- Reviewable:end -->
