### PR TITLE
Switch pub/sub serializers away from unique_ptr

### DIFF
--- a/drake_ros/core/ros_publisher_system.cc
+++ b/drake_ros/core/ros_publisher_system.cc
@@ -13,13 +13,13 @@ namespace drake_ros {
 namespace core {
 struct RosPublisherSystem::Impl {
   // Interface for message (de)serialization.
-  std::unique_ptr<SerializerInterface> serializer;
+  std::shared_ptr<const SerializerInterface> serializer;
   // Publisher for serialized messages.
   std::unique_ptr<internal::Publisher> pub;
 };
 
 RosPublisherSystem::RosPublisherSystem(
-    std::unique_ptr<SerializerInterface> serializer,
+    std::shared_ptr<const SerializerInterface> serializer,
     const std::string& topic_name, const rclcpp::QoS& qos, DrakeRos* ros,
     const std::unordered_set<drake::systems::TriggerType>& publish_triggers,
     double publish_period)

--- a/drake_ros/core/ros_publisher_system.h
+++ b/drake_ros/core/ros_publisher_system.h
@@ -57,7 +57,7 @@ class RosPublisherSystem : public drake::systems::LeafSystem<double> {
    @param[in] publish_period optional publishing period, in seconds.
      Only applicable when periodic publishing is enabled.
    */
-  RosPublisherSystem(std::unique_ptr<SerializerInterface> serializer,
+  RosPublisherSystem(std::shared_ptr<const SerializerInterface> serializer,
                      const std::string& topic_name, const rclcpp::QoS& qos,
                      DrakeRos* ros,
                      const std::unordered_set<drake::systems::TriggerType>&

--- a/drake_ros/core/ros_subscriber_system.cc
+++ b/drake_ros/core/ros_subscriber_system.cc
@@ -35,7 +35,7 @@ class MessageQueue {
 
 struct RosSubscriberSystem::Impl {
   // Interface for message (de)serialization.
-  std::unique_ptr<SerializerInterface> serializer;
+  std::shared_ptr<const SerializerInterface> serializer;
   // Subscription to serialized messages.
   std::shared_ptr<internal::Subscription> sub;
   // Queue of serialized messages.
@@ -45,7 +45,7 @@ struct RosSubscriberSystem::Impl {
 };
 
 RosSubscriberSystem::RosSubscriberSystem(
-    std::unique_ptr<SerializerInterface> serializer,
+    std::shared_ptr<const SerializerInterface> serializer,
     const std::string& topic_name, const rclcpp::QoS& qos, DrakeRos* ros)
     : impl_(new Impl()) {
   impl_->serializer = std::move(serializer);

--- a/drake_ros/core/ros_subscriber_system.h
+++ b/drake_ros/core/ros_subscriber_system.h
@@ -29,7 +29,7 @@ class RosSubscriberSystem : public drake::systems::LeafSystem<double> {
   static std::unique_ptr<RosSubscriberSystem> Make(ArgsT&&... args) {
     // Assume C++ typesupport since this is a C++ template function
     return std::make_unique<RosSubscriberSystem>(
-        std::make_unique<Serializer<MessageT>>(), std::forward<ArgsT>(args)...);
+        std::make_shared<Serializer<MessageT>>(), std::forward<ArgsT>(args)...);
   }
 
   /** A constructor for the ROS subscriber system.
@@ -41,7 +41,7 @@ class RosSubscriberSystem : public drake::systems::LeafSystem<double> {
    @param[in] qos QoS profile for the underlying ROS subscription.
    @param[in] ros interface to a live ROS node to publish from.
    */
-  RosSubscriberSystem(std::unique_ptr<SerializerInterface> serializer,
+  RosSubscriberSystem(std::shared_ptr<const SerializerInterface> serializer,
                       const std::string& topic_name, const rclcpp::QoS& qos,
                       DrakeRos* ros);
 


### PR DESCRIPTION
Towards https://github.com/RobotLocomotion/drake/issues/21968.

This contains the same kind of fixes as https://github.com/RobotLocomotion/drake/pull/19369 and https://github.com/RobotLocomotion/drake/pull/22463, plus one additional change (removing the apparently unnecessary `py::wrapper`).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/374)
<!-- Reviewable:end -->
