### PR TITLE
Fix --incompatible_disallow_empty_glob=true for Bazel 8

### DIFF
--- a/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
@@ -1,7 +1,7 @@
 cc_library(
     name = @name@,
     srcs = @srcs@,
-    hdrs = glob(["{}/**/*.h*".format(x) for x in @headers@]),
+    hdrs = glob(["{}/**/*.h*".format(x) for x in @headers@], allow_empty = True),
     includes = @includes@,
     copts = @copts@,
     defines = @defines@,

--- a/bazel_ros2_rules/ros2/resources/templates/package_py_library.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_py_library.bazel.tpl
@@ -1,6 +1,6 @@
 py_library(
     name = @name@,
-    srcs = glob(["{}/**/*.py".format(x) for x in @tops@]),
+    srcs = glob(["{}/**/*.py".format(x) for x in @tops@], allow_empty = True),
     data = glob(
        include=[
          "{}/**/*.*".format(x) for x in @tops@
@@ -8,6 +8,7 @@ py_library(
          "{}/*".format(x) for x in @eggs@
        ],
        exclude=["**/*.py", "**/*.so"],
+       allow_empty = True,
     ) + @data@,
     imports = @imports@,
     deps = @deps@,

--- a/bazel_ros2_rules/ros2/resources/templates/package_py_library_with_cc_libs.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_py_library_with_cc_libs.bazel.tpl
@@ -7,7 +7,7 @@ cc_library(
 
 py_library(
     name = @name@,
-    srcs = glob(["{}/**/*.py".format(x) for x in @tops@]),
+    srcs = glob(["{}/**/*.py".format(x) for x in @tops@], allow_empty = True),
     data = glob(
        include=[
          "{}/**/*.*".format(x) for x in @tops@
@@ -15,6 +15,7 @@ py_library(
          "{}/*".format(x) for x in @eggs@
        ],
        exclude=["**/*.py", "**/*.so"],
+       allow_empty = True,
     ) + @data@,
     imports = @imports@,
     deps = @deps@,

--- a/bazel_ros2_rules/ros2/tools/common.bzl
+++ b/bazel_ros2_rules/ros2/tools/common.bzl
@@ -17,6 +17,7 @@ def share_filegroup(name, share_directories):
                 "*/*.bash",
                 "*/*.dsv",
             ],
+            allow_empty = True,
         ) if " " not in path],
         # NOTE(hidmic): workaround lack of support for spaces.
         # See https://github.com/bazelbuild/bazel/issues/4327.
@@ -30,7 +31,7 @@ def interfaces_filegroup(name, share_directory):
             "{}/**/*.msg".format(share_directory),
             "{}/**/*.srv".format(share_directory),
             "{}/**/*.action".format(share_directory),
-        ]),
+        ], allow_empty = True),
     )
 
 def incorporate_rmw_implementation(kwargs, env_changes, rmw_implementation):


### PR DESCRIPTION
See https://github.com/bazelbuild/bazel/issues/8195.

I ran an Anzu full local build+test against this patch (still with Bazel 7) and everything passed.

I didn't check that all of these were strictly necessary, I just blindly added the flag in places where it seemed conceivable to fail.

+@EricCousineau-TRI for stamping, please.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/375)
<!-- Reviewable:end -->
