### PR TITLE
Miscellaneous scrapping fixes

### DIFF
--- a/bazel_ros2_rules/ros2/resources/cmake_tools/file_api.py
+++ b/bazel_ros2_rules/ros2/resources/cmake_tools/file_api.py
@@ -69,11 +69,14 @@ class Target:
                 if fragment['role'] == 'flags':
                     self.link_flags.append(fragment['fragment'])
                 elif fragment['role'] == 'libraries':
-                    # In the generated JSON a library can be in quotes (to escape some characters?)
-                    # This escaping creates problem down the line ("/usr/lib/libfoo.so" is *not* a path)
+                    # In the generated JSON a library can be in quotes, in
+                    # order to escape some characters.
+                    # This escaping creates problem down the line,
+                    # "/usr/lib/libfoo.so" is *not* a path.
                     # We remove the escaping here so they can be treated normally
                     link_library = fragment['fragment']
-                    if link_library.startswith('"') and link_library.endswith('"'):
+                    if link_library.startswith('"') and \
+                            link_library.endswith('"'):
                         link_library = link_library.strip('"')
                     self.link_libraries.append(link_library)
                 elif fragment['role'] == 'libraryPath':

--- a/bazel_ros2_rules/ros2/resources/cmake_tools/file_api.py
+++ b/bazel_ros2_rules/ros2/resources/cmake_tools/file_api.py
@@ -69,7 +69,13 @@ class Target:
                 if fragment['role'] == 'flags':
                     self.link_flags.append(fragment['fragment'])
                 elif fragment['role'] == 'libraries':
-                    self.link_libraries.append(fragment['fragment'])
+                    # In the generated JSON a library can be in quotes (to escape some characters?)
+                    # This escaping creates problem down the line ("/usr/lib/libfoo.so" is *not* a path)
+                    # We remove the escaping here so they can be treated normally
+                    link_library = fragment['fragment']
+                    if link_library.startswith('"') and link_library.endswith('"'):
+                        link_library = link_library.strip('"')
+                    self.link_libraries.append(link_library)
                 elif fragment['role'] == 'libraryPath':
                     self.link_search_paths.append(fragment['fragment'])
                 elif fragment['role'] == 'frameworkPath':

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -1,9 +1,26 @@
 import os
 import xml.etree.ElementTree as ET
 
+# Remove elements that have a condition attribute on ROS1
+def remove_ros1_elements(root):
+    ros1_condition_value = "$ROS_VERSION == 1"
+    elements_to_remove = []
+
+    for parent in root.iter():
+        for child in list(parent):
+            if "condition" in child.attrib:
+                if child.get('condition') == ros1_condition_value :
+                    elements_to_remove.append((parent, child))
+                else :
+                    child.attrib.pop("condition")
+
+    for parent, child in elements_to_remove:
+        parent.remove(child)
 
 def parse_package_xml(path_to_package_xml):
     tree = ET.parse(path_to_package_xml)
+
+    remove_ros1_elements(tree.getroot())
 
     depends = set([
         tag.text for tag in tree.findall('./depend')

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -9,9 +9,9 @@ def remove_ros1_elements(root):
     for parent in root.iter():
         for child in list(parent):
             if "condition" in child.attrib:
-                if child.get('condition') == ros1_condition_value :
+                if child.get('condition') == ros1_condition_value:
                     elements_to_remove.append((parent, child))
-                else :
+                else:
                     child.attrib.pop("condition")
 
     for parent, child in elements_to_remove:

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/metadata.py
@@ -3,16 +3,16 @@ import xml.etree.ElementTree as ET
 
 # Remove elements that have a condition attribute on ROS1
 def remove_ros1_elements(root):
-    ros1_condition_value = "$ROS_VERSION == 1"
+    ros1_condition_value = '$ROS_VERSION == 1'
     elements_to_remove = []
 
     for parent in root.iter():
         for child in list(parent):
-            if "condition" in child.attrib:
+            if 'condition' in child.attrib:
                 if child.get('condition') == ros1_condition_value:
                     elements_to_remove.append((parent, child))
                 else:
-                    child.attrib.pop("condition")
+                    child.attrib.pop('condition')
 
     for parent, child in elements_to_remove:
         parent.remove(child)

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/python.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/python.py
@@ -21,7 +21,7 @@ def find_package(name: str) -> Tuple[str, list[str]]:
     top_level = dist.read_text('top_level.txt')
     packages = top_level.splitlines()
     assert len(packages) >= 1
-    top_levels = [str(dist.locate_file(package) for package in packages)]
+    top_levels = [str(dist.locate_file(package)) for package in packages]
     return str(dist._path), top_levels
 
 

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/python.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/python.py
@@ -15,16 +15,14 @@ from ros2bzl.scraping.system import is_system_library
 EXTENSION_SUFFIX: Final[str] = sysconfig.get_config_var('EXT_SUFFIX')
 
 
-def find_package(name: str) -> Tuple[str, str]:
+def find_package(name: str) -> Tuple[str, list[str]]:
     """Find a Python package path and top level module path given its `name`."""
     dist = importlib.metadata.distribution(name)
     top_level = dist.read_text('top_level.txt')
     packages = top_level.splitlines()
     assert len(packages) >= 1
-    if len(packages) > 1:
-        print(f"Multiple top level entries where found in {name}. "
-               "Only the first one will be considered")
-    return str(dist._path), str(dist.locate_file(packages[0]))
+    top_levels = [str(dist.locate_file(package) for package in packages)]
+    return str(dist._path), top_levels
 
 
 def get_packages_with_prefixes(prefixes: Optional[Sequence[str]] = None) -> Dict[str, pathlib.Path]:
@@ -53,9 +51,17 @@ def get_packages_with_prefixes(prefixes: Optional[Sequence[str]] = None) -> Dict
 def collect_python_package_properties(name: str, metadata: Dict[str, Any]) -> PyProperties:
     """Collect Python library properties given package `name` and `metadata`."""
     properties = PyProperties()
-    egg_path, top_level = find_package(name)
-    properties.python_packages = tuple([(egg_path, top_level)])
-    cc_libraries = glob.glob('{}/**/*.so'.format(top_level), recursive=True)
+    egg_path, top_levels = find_package(name)
+    properties.python_packages = tuple(
+        [(egg_path, top_level) for top_level in top_levels]
+    )
+    cc_libraries = sum(
+        [
+            glob.glob("{}/**/*.so".format(top_level), recursive=True)
+            for top_level in top_levels
+        ],
+        [],
+    )
     if cc_libraries:
         cc_libraries.extend(set(
             dep for library in cc_libraries

--- a/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/python.py
+++ b/bazel_ros2_rules/ros2/resources/ros2bzl/scraping/python.py
@@ -20,7 +20,10 @@ def find_package(name: str) -> Tuple[str, str]:
     dist = importlib.metadata.distribution(name)
     top_level = dist.read_text('top_level.txt')
     packages = top_level.splitlines()
-    assert len(packages) == 1
+    assert len(packages) >= 1
+    if len(packages) > 1:
+        print(f"Multiple top level entries where found in {name}. "
+               "Only the first one will be considered")
     return str(dist._path), str(dist.locate_file(packages[0]))
 
 

--- a/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
@@ -1,7 +1,11 @@
 cc_library(
     name = @name@,
     srcs = @srcs@,
-    hdrs = glob(["{}/**/*.h*".format(x) for x in @headers@] + ["{}/**/*.inc".format(x) for x in @headers@], allow_empty = True),
+    hdrs = glob(
+        ["{}/**/*.h*".format(x) for x in @headers@] +
+        ["{}/**/*.inc".format(x) for x in @headers@],
+        allow_empty = True,
+    ),
     includes = @includes@,
     copts = @copts@,
     defines = @defines@,

--- a/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
+++ b/bazel_ros2_rules/ros2/resources/templates/package_cc_library.bazel.tpl
@@ -1,7 +1,7 @@
 cc_library(
     name = @name@,
     srcs = @srcs@,
-    hdrs = glob(["{}/**/*.h*".format(x) for x in @headers@], allow_empty = True),
+    hdrs = glob(["{}/**/*.h*".format(x) for x in @headers@] + ["{}/**/*.inc".format(x) for x in @headers@], allow_empty = True),
     includes = @includes@,
     copts = @copts@,
     defines = @defines@,


### PR DESCRIPTION
Hello drake-ros maintainers,

Thank you for making this project available. We have been using it to build our software for the past months and we have built up a number of patches that we hope can be useful to everyone.

This PR is the first I'm opening and it contains 4 small patches related to various edge cases in the workspace scrapping that we have encountered.

Below is a short summary of the individual patches, I am happy to submit separate PRs if you prefer.

P1: Remove elements that have a condition attribute on ROS1

This is used by a number of packages that are trying to support both versions at the same time.

This patch is actually part of https://github.com/RobotLocomotion/drake-ros/pull/336 we actually had our own patch that does pretty much the same thing (including packages that have the `$ROS_VERSION == 2` condition instead of excluding the `$ROS_VERSION == 1`). However, that PR incorporates more changes this particular fix is not available on main yet so I hope it's ok to bring it in with this PR.

P2: Fix an issue with some Python packages that have multiple entries in the egg `top_level.txt` (seen in `launch_testing for example)

P3: Fix an issue with CMake's JSON where libraries' paths are escaped under some conditions (for example if the workspace path has a `~` character)

P4: Include `*.inc` files in C++ headers of library, afaik, only the `domain_bridge` package uses this extension

Thanks again for making bazel_ros2_rules and I'm looking forward to your feedback.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/378)
<!-- Reviewable:end -->
