### PR TITLE
Migrate from Drake 1.37 to Drake 1.40

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           # TODO : Include rolling later if available on jammy or noble.
           - os_code_name: noble
             ros_distro: jazzy
-            drake_version: 1.37.0
+            drake_version: 1.40.0
     name: test_against_${{matrix.ros_distro}}_debs
     runs-on: ubuntu-latest
     container:
@@ -46,7 +46,7 @@ jobs:
           # TODO : Include rolling later if available on jammy or noble.
           - os_code_name: noble
             ros_distro: jazzy
-            drake_version: 1.37.0
+            drake_version: 1.40.0
     name: test_against_${{matrix.ros_distro}}_archive
     runs-on: ubuntu-latest
     container:

--- a/drake_ros/.bazelrc
+++ b/drake_ros/.bazelrc
@@ -1,6 +1,10 @@
 # Import base-level build configuration.
 import %workspace%/../default.bazelrc
 
+# Default to using pkg-config to locate C++ library dependencies.
+common --@drake//tools/flags:public_repo_default=pkgconfig
+common --@drake//tools/flags:private_runtime_repo_default=external
+
 # Set GCC compiler major version in Noble
 build --@drake//tools/cc_toolchain:compiler_major=13
 

--- a/drake_ros/drake.bzl
+++ b/drake_ros/drake.bzl
@@ -1,5 +1,5 @@
 DRAKE_SUGGESTED_VERSION = struct(
-    url = "https://github.com/RobotLocomotion/drake/archive/refs/tags/v1.37.0.tar.gz",  # noqa
-    sha256 = "6bee6762f74c3ec7933b47de601ac3a1d1790f8cae20aa1aba1f78e2c0817a68",  # noqa,
-    strip_prefix = "drake-1.37.0",
+    url = "https://github.com/RobotLocomotion/drake/archive/refs/tags/v1.40.0.tar.gz",  # noqa
+    sha256 = "9643b76d21b1e2e80c49924d4bd1646a6fe61ea09ef4887dbd6f135dbf5dad7e",  # noqa,
+    strip_prefix = "drake-1.40.0",
 )

--- a/drake_ros/drake_ros/core/cc_pybind.cc
+++ b/drake_ros/drake_ros/core/cc_pybind.cc
@@ -223,9 +223,8 @@ void DefCore(py::module m) {
       .def("get_ros_interface", &RosInterfaceSystem::get_ros_interface,
            py::return_value_policy::reference_internal);
 
-  py::class_<SerializerInterface, py::wrapper<PySerializerInterface>,
-             std::shared_ptr<SerializerInterface>>(m, "SerializerInterface")
-      .def(py::init_alias<>())
+  py::class_<SerializerInterface, std::shared_ptr<SerializerInterface>, PySerializerInterface>(m, "SerializerInterface")
+      .def(py::init<>())
       .def("CreateDefaultValue", &SerializerInterface::CreateDefaultValue)
       .def("GetTypeSupport",
            [](const SerializerInterface& self) {

--- a/drake_ros/drake_ros/core/cc_pybind.cc
+++ b/drake_ros/drake_ros/core/cc_pybind.cc
@@ -224,7 +224,7 @@ void DefCore(py::module m) {
            py::return_value_policy::reference_internal);
 
   py::class_<SerializerInterface, std::shared_ptr<SerializerInterface>,
-	     PySerializerInterface>(m, "SerializerInterface")
+             PySerializerInterface>(m, "SerializerInterface")
       .def(py::init<>())
       .def("CreateDefaultValue", &SerializerInterface::CreateDefaultValue)
       .def("GetTypeSupport",

--- a/drake_ros/drake_ros/core/cc_pybind.cc
+++ b/drake_ros/drake_ros/core/cc_pybind.cc
@@ -223,7 +223,8 @@ void DefCore(py::module m) {
       .def("get_ros_interface", &RosInterfaceSystem::get_ros_interface,
            py::return_value_policy::reference_internal);
 
-  py::class_<SerializerInterface, std::shared_ptr<SerializerInterface>, PySerializerInterface>(m, "SerializerInterface")
+  py::class_<SerializerInterface, std::shared_ptr<SerializerInterface>,
+	     PySerializerInterface>(m, "SerializerInterface")
       .def(py::init<>())
       .def("CreateDefaultValue", &SerializerInterface::CreateDefaultValue)
       .def("GetTypeSupport",

--- a/drake_ros_examples/.bazelrc
+++ b/drake_ros_examples/.bazelrc
@@ -1,5 +1,12 @@
 # Import base-level build configuration.
 import %workspace%/../default.bazelrc
 
+# Default to using pkg-config to locate C++ library dependencies.
+common --@drake//tools/flags:public_repo_default=pkgconfig
+common --@drake//tools/flags:private_runtime_repo_default=external
+
+# Set GCC compiler major version in Noble
+build --@drake//tools/cc_toolchain:compiler_major=13
+
 # Try to import user-specific configuration local to workspace.
 try-import %workspace%/user.bazelrc

--- a/fix_bazel_lint.sh
+++ b/fix_bazel_lint.sh
@@ -32,7 +32,7 @@ script_dir=$(cd $(dirname ${BASH_SOURCE}) && pwd)
 cd ${script_dir}
 
 # Build tooling.
-( cd .lint/ && bazel build @drake//tools/lint/... )
+( cd .lint/ && bazel build @drake//tools/lint:buildifier @drake//tools/lint:bzlcodestyle)
 buildifer=.lint/bazel-bin/external/drake/tools/lint/buildifier
 # N.B. --ignore options taken as of drake v1.10.0.
 bzlcodestyle=".lint/bazel-bin/external/drake/tools/lint/bzlcodestyle --ignore=E265,E302,E305,W504"


### PR DESCRIPTION
Closes https://github.com/RobotLocomotion/drake-ros/issues/380. Drops the dependency on Drake's `pybind` fork in the process.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/387)
<!-- Reviewable:end -->
