### PR TITLE
Update DRAK_SUGGESTED_VERSION to v1.43.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
           # TODO : Include rolling later if available on jammy or noble.
           - os_code_name: noble
             ros_distro: jazzy
-            drake_version: 1.40.0
+            drake_version: 1.43.0
     name: test_against_${{matrix.ros_distro}}_debs
     runs-on: ubuntu-latest
     container:
@@ -46,7 +46,7 @@ jobs:
           # TODO : Include rolling later if available on jammy or noble.
           - os_code_name: noble
             ros_distro: jazzy
-            drake_version: 1.40.0
+            drake_version: 1.43.0
     name: test_against_${{matrix.ros_distro}}_archive
     runs-on: ubuntu-latest
     container:

--- a/drake_ros/drake.bzl
+++ b/drake_ros/drake.bzl
@@ -1,5 +1,5 @@
 DRAKE_SUGGESTED_VERSION = struct(
-    url = "https://github.com/RobotLocomotion/drake/archive/refs/tags/v1.40.0.tar.gz",  # noqa
-    sha256 = "9643b76d21b1e2e80c49924d4bd1646a6fe61ea09ef4887dbd6f135dbf5dad7e",  # noqa,
-    strip_prefix = "drake-1.40.0",
+    url = "https://github.com/RobotLocomotion/drake/archive/refs/tags/v1.43.0.tar.gz",  # noqa
+    sha256 = "635c125187c6758b1bfc7698b59f6f9bfc64a902575e191cccce74be8c6f47ee",  # noqa,
+    strip_prefix = "drake-1.43.0",
 )

--- a/drake_ros/setup/install_prereqs.sh
+++ b/drake_ros/setup/install_prereqs.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -eux -o pipefail
 
+# Start - ROS Installation
+# Install ROS as described in https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html
 apt update && apt install locales
 locale-gen en_US en_US.UTF-8
 update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
@@ -9,14 +11,13 @@ export LANG=en_US.UTF-8
 apt install software-properties-common
 add-apt-repository universe
 
-apt update && apt install curl -y
-curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+sudo apt update && sudo apt install curl -y
+export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
+sudo dpkg -i /tmp/ros2-apt-source.deb
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" |  tee /etc/apt/sources.list.d/ros2.list > /dev/null
+# End - ROS Installation
 
-apt update
-
-apt install ros-dev-tools
 rosdep init || true
 rosdep update
 

--- a/drake_ros_examples/README.md
+++ b/drake_ros_examples/README.md
@@ -13,27 +13,27 @@ To build it for Noble with ROS 2 Jazzy using `colcon` and `ament` (ROS 2's build
 tooling and CMake infrastructure)
 
 1. [Install ROS Jazzy](https://docs.ros.org/en/jazzy/Installation.html) \
-   Taken from the website (be sure to review these commands before executing!)
+    Taken from the website (be sure to review these commands before executing!)
 
-   ```sh
-   sudo apt install software-properties-common
-   sudo add-apt-repository universe
-   sudo apt update && sudo apt install curl
-   sudo curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-   echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" | sudo tee /etc/apt/sources.list.d/ros2.list > /dev/null
-   sudo apt update
-   # Install the desktop user entry point.
-   sudo apt install ros-jazzy-desktop
-   # Install dev tools.
-   sudo apt install ros-dev-tools
+    ```sh
+    sudo apt install software-properties-common
+    sudo add-apt-repository universe
+    sudo apt update && sudo apt install curl -y
+    export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+    curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
+    sudo dpkg -i /tmp/ros2-apt-source.deb
+    # Install the desktop user entry point.
+    sudo apt install ros-jazzy-desktop
+    # Install dev tools.
+    sudo apt install ros-dev-tools
 
-   # Update dependencies index.
-   rosdep update
-   ```
+    # Update dependencies index.
+    rosdep update
+    ```
 
-   For other entry points aside from `ros-jazzy-desktop`, please see the
-   Jazzy section of REP 2001: \
-   <https://www.ros.org/reps/rep-2001.html#jazzy-jalisco-may-2024-may-2029>
+    For other entry points aside from `ros-jazzy-desktop`, please see the
+    Jazzy section of REP 2001: \
+    <https://www.ros.org/reps/rep-2001.html#jazzy-jalisco-may-2024-may-2029>
 
 1. Source your ROS installation
 

--- a/drake_ros_examples/setup/install_prereqs.sh
+++ b/drake_ros_examples/setup/install_prereqs.sh
@@ -9,12 +9,22 @@ export LANG=en_US.UTF-8
 apt install software-properties-common
 add-apt-repository universe
 
-apt update && apt install curl -y
-curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
+# Start - ROS Installation
+# Install ROS as described in https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html
+apt update && apt install locales
+locale-gen en_US en_US.UTF-8
+update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+export LANG=en_US.UTF-8
 
-echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" |  tee /etc/apt/sources.list.d/ros2.list > /dev/null
+apt install software-properties-common
+add-apt-repository universe
 
-apt update
+sudo apt update && sudo apt install curl -y
+export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
+sudo dpkg -i /tmp/ros2-apt-source.deb
+
+# End - ROS Installation
 
 apt install ros-dev-tools ros-jazzy-rmw-cyclonedds-cpp ros-jazzy-rviz2 ros-jazzy-ros2cli-common-extensions
 

--- a/ros2_example_bazel_installed/setup/install_prereqs.sh
+++ b/ros2_example_bazel_installed/setup/install_prereqs.sh
@@ -74,9 +74,23 @@ if [[ -z "${ROS2_DISTRO_PREFIX:-}" ]]; then
   apt install software-properties-common
   add-apt-repository universe
 
-  curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key | apt-key --keyring /usr/share/keyrings/ros-archive-keyring.gpg add -
-  echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu $(. /etc/os-release && echo $UBUNTU_CODENAME) main" |  tee /etc/apt/sources.list.d/ros2.list > /dev/null
-  apt update
+# Start - ROS Installation
+# Install ROS as described in https://docs.ros.org/en/jazzy/Installation/Ubuntu-Install-Debs.html
+apt update && apt install locales
+locale-gen en_US en_US.UTF-8
+update-locale LC_ALL=en_US.UTF-8 LANG=en_US.UTF-8
+export LANG=en_US.UTF-8
+
+apt install software-properties-common
+add-apt-repository universe
+
+sudo apt update && sudo apt install curl -y
+export ROS_APT_SOURCE_VERSION=$(curl -s https://api.github.com/repos/ros-infrastructure/ros-apt-source/releases/latest | grep -F "tag_name" | awk -F\" '{print $4}')
+curl -L -o /tmp/ros2-apt-source.deb "https://github.com/ros-infrastructure/ros-apt-source/releases/download/${ROS_APT_SOURCE_VERSION}/ros2-apt-source_${ROS_APT_SOURCE_VERSION}.$(. /etc/os-release && echo $VERSION_CODENAME)_all.deb" # If using Ubuntu derivates use $UBUNTU_CODENAME
+sudo dpkg -i /tmp/ros2-apt-source.deb
+
+# End - ROS Installation
+
 fi
 
 # Ensure a full ROS 2 desktop install


### PR DESCRIPTION
This patch updates the ROS2 keys installation and updates drake to v1.43.0.

Closes #385, #390 and #393.