### PR TITLE
Improve ros_launch support for launch files

### DIFF
--- a/bazel_ros2_rules/lib/ament_index.bzl
+++ b/bazel_ros2_rules/lib/ament_index.bzl
@@ -73,17 +73,14 @@ def _ament_index_share_files_impl(ctx):
             )
             root_symlinks[symlink_path] = file
 
-    for exe in ctx.attr.executables:
-        exe_file = exe.files_to_run.executable
-        if exe_file == None:
-            continue
+    for executable in ctx.attr.executables:
         symlink_path = paths.join(
             ctx.attr.prefix,
             "lib",
             ctx.attr.package_name,
-            exe_file.basename,
+            executable.files_to_run.executable.basename,
         )
-        root_symlinks[symlink_path] = exe_file
+        root_symlinks[symlink_path] = executable.files_to_run.executable
 
     return [
         AmentIndex(prefix = ctx.attr.prefix),
@@ -101,7 +98,7 @@ ament_index_share_files = rule(
         ),
         executables = attr.label_list(
             allow_empty = True,
-            allow_files = True,
+            allow_files = False,
         ),
         # A prefix is required because the shim can't prepend the runfiles
         # root to AMENT_PREFIX_PATH

--- a/bazel_ros2_rules/lib/ament_index.bzl
+++ b/bazel_ros2_rules/lib/ament_index.bzl
@@ -74,6 +74,8 @@ def _ament_index_share_files_impl(ctx):
             root_symlinks[symlink_path] = file
 
     for executable in ctx.attr.executables:
+        if executable.files_to_run.executable == None:
+            fail("{} is not an executable target".format(executable.label))
         symlink_path = paths.join(
             ctx.attr.prefix,
             "lib",

--- a/bazel_ros2_rules/lib/ament_index.bzl
+++ b/bazel_ros2_rules/lib/ament_index.bzl
@@ -47,22 +47,15 @@ Recursively aggregates AmentIndex prefixes from dependencies into one provider.
 """
 
 def _ament_index_share_files_impl(ctx):
-    # declare that a "package" with the given name exists
     package_marker_path = paths.join(
         ctx.attr.prefix,
         "share/ament_index/resource_index/packages/",
         ctx.attr.package_name,
     )
     package_marker_out = ctx.actions.declare_file(package_marker_path)
-    ctx.actions.write(
-        output = package_marker_out,
-        content = "",
-    )
+    ctx.actions.write(output = package_marker_out, content = "")
 
-    # Symlink sources into the share directory
-    runfiles_symlinks = {
-        package_marker_path: package_marker_out,
-    }
+    root_symlinks = {package_marker_path: package_marker_out}
 
     for src in ctx.attr.srcs:
         for file in depset(transitive = [
@@ -78,12 +71,24 @@ def _ament_index_share_files_impl(ctx):
                 ctx.attr.package_name,
                 sp,
             )
-            runfiles_symlinks[symlink_path] = file
+            root_symlinks[symlink_path] = file
+
+    for exe in ctx.attr.executables:
+        exe_file = exe.files_to_run.executable
+        if exe_file == None:
+            continue
+        symlink_path = paths.join(
+            ctx.attr.prefix,
+            "lib",
+            ctx.attr.package_name,
+            exe_file.basename,
+        )
+        root_symlinks[symlink_path] = exe_file
 
     return [
         AmentIndex(prefix = ctx.attr.prefix),
         DefaultInfo(
-            runfiles = ctx.runfiles(root_symlinks = runfiles_symlinks),
+            runfiles = ctx.runfiles(root_symlinks = root_symlinks),
         ),
     ]
 
@@ -91,8 +96,11 @@ ament_index_share_files = rule(
     attrs = dict(
         package_name = attr.string(mandatory = True),
         srcs = attr.label_list(
-            mandatory = True,
-            allow_empty = False,
+            allow_empty = True,
+            allow_files = True,
+        ),
+        executables = attr.label_list(
+            allow_empty = True,
             allow_files = True,
         ),
         # A prefix is required because the shim can't prepend the runfiles
@@ -105,14 +113,17 @@ ament_index_share_files = rule(
     provides = [AmentIndex],
 )
 """
-Creates an ament resource index and share/ directory for a single package.
+Creates an ament resource index for a single ROS 2 package.
 
-This creates both a package marker for a package, and a share directory
-for that package.
-Files in `srcs` will be added to `share/package_name`.
-A target depending on this one will be able to access the files in the
-share directory using the package's share directory joined with the
-files they expect.
+Files in `srcs` are symlinked under `<prefix>/share/<package_name>/`,
+enabling ament_index lookups such as `get_package_share_directory()`.
+
+Executable targets in `executables` are symlinked under
+`<prefix>/lib/<package_name>/`, enabling
+`launch_ros.actions.Node(package=..., executable=...)` to find Bazel-built
+binaries without a colcon install space.
+
+Both can be used together in a single rule invocation.
 
     d = ament_index_cpp::get_package_share_directory("package_name")
     file = join(d, "short_path of file")
@@ -132,11 +143,12 @@ TODO(sloretz) detect and error when a target is given two ament indexes
 with the same package.
 
 Args:
-    package_name: name of a ROS 2 package to which these share files belong
+    package_name: name of a ROS 2 package
     srcs: targets whose files are placed into the share directory. Both
       direct files and transitive runfiles are included.
+    executables: executable targets to expose under lib/.
     prefix: optional prefix to give to the generated runfiles.
-    strip_prefix: optional prefix to strip from the short_path of the files
+    strip_prefix: optional prefix to strip from the short_path of srcs files.
 
 Provides:
     AmentIndex: a prefix path where the ament resource index was generated.

--- a/bazel_ros2_rules/lib/private/ros_py.bzl
+++ b/bazel_ros2_rules/lib/private/ros_py.bzl
@@ -195,7 +195,6 @@ def ros_launch(
         name,
         launch_file,
         args = [],
-        data = [],
         deps = [],
         visibility = None,
         # TODO(eric.cousineau): Remove this once Bazel provides a way to tell
@@ -213,6 +212,7 @@ def ros_launch(
         #   }
         executables = {},
         **kwargs):
+    data = []
     main = "{}_roslaunch_main.py".format(name)
     launch_respath = _make_respath(launch_file, workspace_name)
 
@@ -234,6 +234,8 @@ def ros_launch(
     )
 
     for pkg_name, pkg_executables in executables.items():
+        if type(pkg_executables) != type([]):
+            fail("executables['{}'] must be a list, got {}".format(pkg_name, type(pkg_executables)))
         index_target = "_{}_ament_index_{}".format(name, pkg_name)
         ament_index_share_files(
             name = index_target,

--- a/bazel_ros2_rules/lib/private/ros_py.bzl
+++ b/bazel_ros2_rules/lib/private/ros_py.bzl
@@ -1,6 +1,10 @@
 # -*- python -*-
 
 load(
+    "@bazel_ros2_rules//lib:ament_index.bzl",
+    "ament_index_share_files",
+)
+load(
     "@bazel_ros2_rules//lib:kwargs.bzl",
     "filter_to_only_common_kwargs",
     "remove_test_specific_kwargs",
@@ -198,6 +202,16 @@ def ros_launch(
         # runfiles.py to use "this repository" in a way that doesn't require
         # bespoke information.
         workspace_name = None,
+        # dict mapping ROS 2 package name to a list of executable
+        # targets to expose via the ament resource index, enabling
+        # launch_ros.actions.Node(package=..., executable=...) to find
+        # Bazel-built binaries without a colcon install space.
+        # Example:
+        #   executables = {
+        #       "my_pkg": [":talker", ":listener"],
+        #       "other_pkg": ["//other_pkg:some_node"],
+        #   }
+        executables = {},
         **kwargs):
     main = "{}_roslaunch_main.py".format(name)
     launch_respath = _make_respath(launch_file, workspace_name)
@@ -218,6 +232,17 @@ def ros_launch(
             REPOSITORY_ROOT + ":ros2",
         ],
     )
+
+    for pkg_name, pkg_executables in executables.items():
+        index_target = "_{}_ament_index_{}".format(name, pkg_name)
+        ament_index_share_files(
+            name = index_target,
+            package_name = pkg_name,
+            executables = pkg_executables,
+            visibility = ["//visibility:private"],
+        )
+        data = data + pkg_executables + [":" + index_target]
+
     data = data + [launch_file]
 
     if "tags" not in kwargs:

--- a/bazel_ros2_rules/lib/private/ros_py.bzl
+++ b/bazel_ros2_rules/lib/private/ros_py.bzl
@@ -178,12 +178,7 @@ os.execv(ros2_bin, args)
 def _make_respath(relpath, workspace_name):
     repo = native.repository_name()
     if repo == "@":
-        if workspace_name == None:
-            fail(
-                "Please provide `ros_launch(*, workspace_name)` so that " +
-                "paths can be resolved properly",
-            )
-        repo = workspace_name
+        repo = workspace_name if workspace_name != None else native.module_name()
     pkg = native.package_name()
     if pkg != "":
         pieces = [repo, pkg, relpath]
@@ -195,24 +190,26 @@ def ros_launch(
         name,
         launch_file,
         args = [],
+        data = [],
         deps = [],
         visibility = None,
-        # TODO(eric.cousineau): Remove this once Bazel provides a way to tell
-        # runfiles.py to use "this repository" in a way that doesn't require
-        # bespoke information.
+        # Optional: overrides the Bzlmod module name as the ament package name.
+        # Only needed when the desired package name differs from the module name.
         workspace_name = None,
-        # dict mapping ROS 2 package name to a list of executable
-        # targets to expose via the ament resource index, enabling
-        # launch_ros.actions.Node(package=..., executable=...) to find
-        # Bazel-built binaries without a colcon install space.
+        # Executable targets to expose via the ament resource index under
+        # lib/<package_name>/, enabling
+        # launch_ros.actions.Node(package=<package_name>, executable=...) to
+        # find Bazel-built binaries without a colcon install space.
         # Example:
-        #   executables = {
-        #       "my_pkg": [":talker", ":listener"],
-        #       "other_pkg": ["//other_pkg:some_node"],
-        #   }
-        executables = {},
+        #   executables = [":talker", ":listener"],
+        executables = [],
+        # Data file targets to expose via the ament resource index under
+        # share/<package_name>/, enabling FindPackageShare(<package_name>)
+        # and get_package_share_directory(<package_name>) to locate them.
+        # Example:
+        #   share = ["//my_pkg:config_files"],
+        share = [],
         **kwargs):
-    data = []
     main = "{}_roslaunch_main.py".format(name)
     launch_respath = _make_respath(launch_file, workspace_name)
 
@@ -233,17 +230,17 @@ def ros_launch(
         ],
     )
 
-    for pkg_name, pkg_executables in executables.items():
-        if type(pkg_executables) != type([]):
-            fail("executables['{}'] must be a list, got {}".format(pkg_name, type(pkg_executables)))
-        index_target = "_{}_ament_index_{}".format(name, pkg_name)
+    if executables or share:
+        package_name = workspace_name if workspace_name != None else native.module_name()
+        index_target = "_{}_ament_index".format(name)
         ament_index_share_files(
             name = index_target,
-            package_name = pkg_name,
-            executables = pkg_executables,
+            package_name = package_name,
+            executables = executables,
+            srcs = share,
             visibility = ["//visibility:private"],
         )
-        data = data + pkg_executables + [":" + index_target]
+        data = data + executables + share + [":" + index_target]
 
     data = data + [launch_file]
 

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -240,12 +240,10 @@ workspace_name = "ros2_example_bazel_installed"
 # by registering the Bazel-built binaries in a fake ament prefix.
 ros_launch(
     name = "roslaunch_eg_py",
-    executables = {
-        "ros2_example_apps": [
-            ":eg_listener",
-            ":eg_talker",
-        ],
-    },
+    executables = [
+        ":eg_listener",
+        ":eg_talker",
+    ],
     launch_file = "eg_launch.py",
     workspace_name = workspace_name,
 )
@@ -253,12 +251,10 @@ ros_launch(
 # Uses an xml launch file to spawn the talker and listener.
 ros_launch(
     name = "roslaunch_eg_xml",
-    executables = {
-        "ros2_example_apps": [
-            ":eg_listener",
-            ":eg_talker",
-        ],
-    },
+    executables = [
+        ":eg_listener",
+        ":eg_talker",
+    ],
     launch_file = "eg_launch.xml",
     workspace_name = workspace_name,
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -233,15 +233,19 @@ ros_cc_binary(
 # See bazel_ros2_rules/ros2/README.md, Launch Files, for notes on
 # features and limitations.
 
-# Uses a python launch file to spawn the talker and listener.
 workspace_name = "ros2_example_bazel_installed"
 
+# Uses a python launch file to spawn the talker and listener.
+# Note: it also uses launch_ros.actions.Node, the natural ROS 2 pattern,
+# by registering the Bazel-built binaries in a fake ament prefix.
 ros_launch(
     name = "roslaunch_eg_py",
-    data = [
-        ":eg_listener",
-        ":eg_talker",
-    ],
+    executables = {
+        "ros2_example_apps": [
+            ":eg_listener",
+            ":eg_talker",
+        ],
+    },
     launch_file = "eg_launch.py",
     workspace_name = workspace_name,
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
+++ b/ros2_example_bazel_installed/ros2_example_apps/BUILD.bazel
@@ -253,10 +253,12 @@ ros_launch(
 # Uses an xml launch file to spawn the talker and listener.
 ros_launch(
     name = "roslaunch_eg_xml",
-    data = [
-        ":eg_listener",
-        ":eg_talker",
-    ],
+    executables = {
+        "ros2_example_apps": [
+            ":eg_listener",
+            ":eg_talker",
+        ],
+    },
     launch_file = "eg_launch.xml",
     workspace_name = workspace_name,
 )

--- a/ros2_example_bazel_installed/ros2_example_apps/eg_launch.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/eg_launch.py
@@ -1,21 +1,17 @@
 from launch import LaunchDescription
-from launch.actions import ExecuteProcess
-from python.runfiles import runfiles
+import launch_ros.actions
 
 
 def generate_launch_description():
-    # See bazel_ros2_rules/ros2/README.md, Launch Files, for notes on
-    # features and limitations.
-    r = runfiles.Create()
-    prefix = "ros2_example_bazel_installed/ros2_example_apps"
-    talker_bin = r.Rlocation(f"{prefix}/eg_talker")
-    listener_bin = r.Rlocation(f"{prefix}/eg_listener")
-
     return LaunchDescription(
         [
-            # Running a talker written in python.
-            ExecuteProcess(cmd=[talker_bin]),
-            # Running a listener written in cpp.
-            ExecuteProcess(cmd=[listener_bin]),
+            launch_ros.actions.Node(
+                package="ros2_example_apps",
+                executable="eg_talker",
+            ),
+            launch_ros.actions.Node(
+                package="ros2_example_apps",
+                executable="eg_listener",
+            ),
         ]
     )

--- a/ros2_example_bazel_installed/ros2_example_apps/eg_launch.py
+++ b/ros2_example_bazel_installed/ros2_example_apps/eg_launch.py
@@ -6,11 +6,11 @@ def generate_launch_description():
     return LaunchDescription(
         [
             launch_ros.actions.Node(
-                package="ros2_example_apps",
+                package="ros2_example_bazel_installed",
                 executable="eg_talker",
             ),
             launch_ros.actions.Node(
-                package="ros2_example_apps",
+                package="ros2_example_bazel_installed",
                 executable="eg_listener",
             ),
         ]


### PR DESCRIPTION
# Motivation
Previously, `ros_launch` required users to manually resolve Bazel runfile paths and use `ExecuteProcess` to launch nodes. This PR enables the standard ROS 2 launch pattern (`launch_ros.actions.Node`) to work with Bazel-built binaries by registering them in a fake ament prefix at build time.

For more details, you can check out this issue: https://github.com/RobotLocomotion/drake-ros/issues/417

# Implementation details
- Extends `ament_index_share_files` in `ament_index.bzl` to support an `executables` attribute, which symlinks Bazel-built binaries under `<prefix>/lib/<package_name>/`. This makes them discoverable by `launch_ros.actions.Node(package=..., executable=...)` without a colcon install space.
- Adds an `executables` parameter to ros_launch: a dict mapping ROS 2 package names to lists of executable targets. The macro automatically creates the ament index entries and wires up the runfiles.
- Removes the `data` parameter from `ros_launch` (executables registered via executables are automatically added to the binary's runfiles).
- Updates the example launch app to use the idiomatic `launch_ros.actions.Node` pattern instead of resolving and spawning binaries manually via `ExecuteProcess` + runfiles.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/RobotLocomotion/drake-ros/419)
<!-- Reviewable:end -->
